### PR TITLE
Add analyze command to list all the Orbiter components usage

### DIFF
--- a/.codemodrc.json
+++ b/.codemodrc.json
@@ -11,6 +11,13 @@
       "description": "The component name to migrate. If not provided, all components will be migrated.",
       "required": false,
       "default": "all"
+    },
+    {
+      "name": "a",
+      "kind": "string",
+      "description": "Analyze and list all components that need to be migrated. ",
+      "required": false,
+      "default": "orbiter-usage.json"
     }
   ],
   "meta": {

--- a/README.md
+++ b/README.md
@@ -22,7 +22,17 @@ export function App() {
 }
 ```
 
-### Run Migrates for All Components
+### Analyze Component Usages
+
+To find out what components and what properties are used you can use the following command. This command writes the usages in `orbiter-usage.json` file.
+
+⚠️ It is important to pass `-n 1` to use only one thread and get reliable output.
+
+```bash
+npx codemod workleap/orbiter-to-hopper -a -n 1
+```
+
+### Run Migrations for All Components
 
 ```bash
 npx codemod workleap/orbiter-to-hopper
@@ -34,13 +44,13 @@ or
 npx codemod workleap/orbiter-to-hopper -c all
 ```
 
-### Run Migrates Only for One Component
+### Run Migrations Only for One Component
 
 ```bash
 npx codemod workleap/orbiter-to-hopper -c Div
 ```
 
-### Run Migrates Only in Specific Path
+### Run Migrations Only in Specific Path
 
 ```bash
 npx codemod workleap/orbiter-to-hopper -t /app/users

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import type {
   Options,
 } from "jscodeshift";
 import { mappings } from "./mappings.js";
+import { analyze } from "./utils/analyze.js";
 import { migrate } from "./utils/migrate.js";
 import { migrateComponent } from "./utils/migrateComponent.js";
 import { MapMetaData, Runtime } from "./utils/types.js";
@@ -22,8 +23,15 @@ export default function transform(
   const runtime: Runtime = {
     j: api.jscodeshift,
     root: api.jscodeshift(file.source),
+    filePath: file.path,
     mappings: mappings,
   };
 
-  return migrate(runtime, options);
+  if (options?.a !== undefined) {
+    const outputPath = options.a as string;
+    const result = analyze(runtime, outputPath, options);
+    return result.source;
+  } else {
+    return migrate(runtime, options);
+  }
 }

--- a/src/utils/analyze.ts
+++ b/src/utils/analyze.ts
@@ -1,0 +1,162 @@
+import { existsSync, readFileSync, writeFileSync } from "fs";
+import { Options } from "jscodeshift";
+import { Runtime } from "./types.js";
+
+/**
+ * Merges two analysis result objects by combining their property arrays
+ *
+ * @param existingResults - The existing analysis results
+ * @param newResults - The new analysis results to merge
+ * @returns The merged analysis results
+ */
+export function mergeAnalysisResults(
+  existingResults: Record<string, string[]>,
+  newResults: Record<string, string[]>
+): Record<string, string[]> {
+  const merged: Record<string, string[]> = { ...existingResults };
+
+  // Merge the new results into the existing ones
+  Object.entries(newResults).forEach(([componentName, props]) => {
+    if (merged[componentName]) {
+      // Create a Set to deduplicate props
+      const uniqueProps = new Set([...merged[componentName], ...props]);
+      merged[componentName] = Array.from(uniqueProps);
+    } else {
+      merged[componentName] = props;
+    }
+  });
+
+  return merged;
+}
+
+/**
+ * Analyzes a file to find all component usages from the specified source package
+ * and collects all properties used for each component.
+ *
+ * @param runtime - The runtime context containing jscodeshift and AST
+ * @param outputPath - The path to save the analysis output, or null to skip file output
+ * @param options - Optional jscodeshift options
+ * @returns The original source code and the analysis results
+ */
+export function analyze(
+  runtime: Runtime,
+  outputPath: string | null,
+  options?: Options & { sourcePackage?: string }
+): { source: string | undefined; analysisResults: Record<string, string[]> } {
+  const { j, root, mappings } = runtime;
+  const sourcePackage = options?.sourcePackage || mappings.sourcePackage;
+  const componentUsage: Record<string, Set<string>> = {};
+
+  // Find all import declarations from the source package
+  const sourceImports = root.find(j.ImportDeclaration, {
+    source: { value: sourcePackage },
+  });
+
+  // Extract locally imported component names
+  const importedComponents: Record<string, string> = {};
+  // Keep track of potential components (will be confirmed by JSX usage)
+  const potentialComponents: Set<string> = new Set();
+
+  sourceImports.forEach((path) => {
+    const specifiers = path.node.specifiers || [];
+
+    specifiers.forEach((specifier) => {
+      if (j.ImportSpecifier.check(specifier) && specifier.imported) {
+        const importedName = specifier.imported.name;
+        const localName = specifier.local?.name || importedName;
+
+        // Step 1: Consider all imports as potential components initially
+        // We'll confirm them later by checking for JSX usage
+        importedComponents[localName] = importedName;
+
+        // Step 2: Prioritize components with PascalCase names
+        // (following React component naming convention)
+        if (importedName.charAt(0) === importedName.charAt(0).toUpperCase()) {
+          potentialComponents.add(localName);
+        }
+
+        // Note: We'll confirm all components by actual JSX usage,
+        // regardless of naming convention
+      }
+    });
+  });
+
+  // Find all JSX elements that use the imported components
+  // Confirmed components that are actually used in JSX
+  const confirmedComponents: Set<string> = new Set();
+
+  Object.entries(importedComponents).forEach(([localName, originalName]) => {
+    // Find all JSX opening elements with the local component name
+    const jsxUsages = root.find(j.JSXOpeningElement, {
+      name: { name: localName },
+    });
+
+    // If this potential component is actually used in JSX, then it's confirmed as a component
+    if (jsxUsages.size() > 0) {
+      confirmedComponents.add(originalName);
+      // Initialize the set to collect props for this confirmed component
+      componentUsage[originalName] = new Set<string>();
+
+      // Collect all attributes used with this component
+      jsxUsages.forEach((path) => {
+        const attributes = path.node.attributes || [];
+
+        // Collect attribute names for this component
+        attributes.forEach((attr) => {
+          if (
+            attr.type === "JSXAttribute" &&
+            attr.name &&
+            attr.name.type === "JSXIdentifier"
+          ) {
+            componentUsage[originalName]?.add(attr.name.name);
+          }
+        });
+      });
+    }
+  });
+
+  // Generate the output as JSON
+  const outputJson: Record<string, string[]> = {};
+  Object.entries(componentUsage).forEach(([componentName, props]) => {
+    outputJson[componentName] = Array.from(props);
+  });
+
+  // Write the output to a file
+  if (Object.keys(outputJson).length > 0 && outputPath !== null) {
+    try {
+      let finalResults = outputJson;
+
+      // Check if the file already exists and read its content
+      if (existsSync(outputPath)) {
+        try {
+          const existingContent = readFileSync(outputPath, "utf8");
+          const existingResults = JSON.parse(existingContent);
+
+          // Merge existing results with new results
+          finalResults = mergeAnalysisResults(existingResults, outputJson);
+          // console.log(
+          //   `Merged new analysis with existing data in ${outputPath}`
+          // );
+        } catch (readError) {
+          // console.warn(
+          //   `Could not read or parse existing file: ${readError}. Creating a new file.`
+          // );
+        }
+      }
+
+      // Write the combined results
+      writeFileSync(outputPath, JSON.stringify(finalResults, null, 2));
+    } catch (error) {
+      console.error(`Error writing analysis to file: ${error}`);
+    }
+  } else if (Object.keys(outputJson).length === 0) {
+    // console.log(
+    //   "No component usage found from the source package in: " + runtime.filePath
+    // );
+  }
+
+  return {
+    source: root.toSource(),
+    analysisResults: outputJson,
+  };
+}

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -8,6 +8,7 @@ export interface Runtime {
   j: core.JSCodeshift;
   root: Collection<ASTNode>;
   mappings: MapMetaData;
+  filePath: string;
 }
 
 /**

--- a/test-output.json
+++ b/test-output.json
@@ -1,0 +1,6 @@
+{
+  "Button": [
+    "disabled",
+    "onClick"
+  ]
+}

--- a/test/test.ts
+++ b/test/test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { describe, test } from "vitest";
 import transform from "../src/index.js";
 import { mappings as initialMappings, mappings } from "../src/mappings.js";
+import { analyze, mergeAnalysisResults } from "../src/utils/analyze.js";
 import { migrate } from "../src/utils/migrate.js";
 import { MapMetaData, Runtime } from "../src/utils/types.js";
 
@@ -30,6 +31,7 @@ const getRuntime = (
   const api = buildApi("tsx");
   return {
     root: api.jscodeshift(source),
+    filePath: "test.tsx",
     j: api.j,
     mappings: {
       ...initialMappings,
@@ -140,5 +142,203 @@ describe("o2h-migration", () => {
     );
 
     assert.deepEqual(actualOutput, OUTPUT);
+  });
+});
+
+describe("component usage analysis", () => {
+  test("analyze basic component usage", () => {
+    const INPUT = `import { Div, Text } from "@workleap/orbiter-ui"; export function App() { return <><Div border="1px" width="120px" /><Text fontSize="14px" /></>; }`;
+
+    const { analysisResults } = analyze(getRuntime(INPUT), null);
+
+    // Check that the results are in the expected JSON format
+    assert.ok(
+      analysisResults.Div,
+      "Div component should be present in results"
+    );
+    assert.ok(
+      analysisResults.Text,
+      "Text component should be present in results"
+    );
+    assert.deepEqual([...analysisResults.Div].sort(), ["border", "width"]);
+    assert.deepEqual(analysisResults.Text, ["fontSize"]);
+  });
+
+  test("analyze component with alias", () => {
+    const INPUT = `import { Div as CustomDiv, Text } from "@workleap/orbiter-ui"; export function App() { return <CustomDiv border="1px" width="120px" />; }`;
+
+    const { analysisResults } = analyze(getRuntime(INPUT), null);
+
+    const expectedResults = {
+      Div: ["border", "width"],
+    };
+
+    assert.deepEqual(analysisResults, expectedResults);
+  });
+
+  test("analyze includes non-mapped components", () => {
+    const INPUT = `import { UnknownComponent } from "@workleap/orbiter-ui"; export function App() { return <UnknownComponent prop1="value" prop2="value" />; }`;
+
+    const { analysisResults } = analyze(getRuntime(INPUT), null);
+
+    // Should include the unknown component and its props
+    assert.ok(
+      analysisResults.UnknownComponent,
+      "UnknownComponent should be present in results"
+    );
+    assert.deepEqual(
+      new Set(analysisResults.UnknownComponent),
+      new Set(["prop1", "prop2"])
+    );
+  });
+
+  test("analyze complex component with multiple usages", () => {
+    const INPUT = `
+      import { Div, Text } from "@workleap/orbiter-ui";
+      export function App() {
+        return (
+          <>
+            <Div width="100px" height="200px">
+              <Text fontSize="14px" />
+            </Div>
+            <Div height="50px" maxWidth="300px" />
+            <Text fontWeight="bold" />
+          </>
+        );
+      }
+    `;
+
+    const { analysisResults } = analyze(getRuntime(INPUT), null);
+
+    const expectedResults = {
+      Div: ["width", "height", "maxWidth"],
+      Text: ["fontSize", "fontWeight"],
+    };
+
+    // Use a deep comparison that doesn't care about array order
+    assert.deepEqual(
+      Object.keys(analysisResults).sort(),
+      Object.keys(expectedResults).sort()
+    );
+
+    // Check each array separately to handle unsorted arrays
+    assert.ok(
+      analysisResults.Div,
+      "Div component should be present in results"
+    );
+    assert.ok(
+      analysisResults.Text,
+      "Text component should be present in results"
+    );
+    assert.deepEqual(
+      new Set(analysisResults.Div),
+      new Set(expectedResults.Div)
+    );
+    assert.deepEqual(
+      new Set(analysisResults.Text),
+      new Set(expectedResults.Text)
+    );
+  });
+
+  test("analyze with custom source package", () => {
+    const INPUT = `
+      import { CustomComponent } from "@custom/package";
+      export function App() {
+        return <CustomComponent prop1="value1" prop2="value2" />;
+      }
+    `;
+
+    const { analysisResults } = analyze(getRuntime(INPUT), null, {
+      sourcePackage: "@custom/package",
+    });
+
+    assert.ok(
+      analysisResults.CustomComponent,
+      "CustomComponent should be present in results"
+    );
+    assert.deepEqual(
+      new Set(analysisResults.CustomComponent),
+      new Set(["prop1", "prop2"])
+    );
+  });
+
+  test("analyze ignores hooks and utility functions that aren't used as components", () => {
+    const INPUT = `
+      import { Button, Text, useHook, utilFunction } from "@workleap/orbiter-ui";
+      export function App() {
+        const value = useHook();
+        utilFunction();
+        return (
+          <>
+            <Button onClick={() => {}} size="lg" />
+            <Text>Content</Text>
+          </>
+        );
+      }
+    `;
+
+    const { analysisResults } = analyze(getRuntime(INPUT), null);
+
+    // Should only include components used with JSX, not hooks or utility functions
+    assert.deepEqual(
+      Object.keys(analysisResults).sort(),
+      ["Button", "Text"].sort(),
+      "Only actual components should be included in results"
+    );
+    assert.ok(
+      analysisResults.Button,
+      "Button component should be present in results"
+    );
+    assert.ok(
+      analysisResults.Text,
+      "Text component should be present in results"
+    );
+    assert.strictEqual(
+      analysisResults.useHook,
+      undefined,
+      "Hook should not be present in results"
+    );
+    assert.strictEqual(
+      analysisResults.utilFunction,
+      undefined,
+      "Utility function should not be present in results"
+    );
+  });
+});
+
+describe("analyze file aggregation", () => {
+  test("mergeAnalysisResults combines component props correctly", () => {
+    const existingResults = {
+      Button: ["variant", "size", "disabled"],
+      Text: ["fontSize", "color"],
+    };
+
+    const newResults = {
+      Button: ["variant", "onClick", "aria-label"],
+      Div: ["width", "padding"],
+    };
+
+    const mergedResults = mergeAnalysisResults(existingResults, newResults);
+
+    // Check that Button props are merged correctly with duplicates removed
+    assert.deepEqual(
+      new Set(mergedResults.Button),
+      new Set(["variant", "size", "disabled", "onClick", "aria-label"]),
+      "Button props should be merged without duplicates"
+    );
+
+    // Check that Text props remain unchanged
+    assert.deepEqual(
+      mergedResults.Text,
+      ["fontSize", "color"],
+      "Text props should remain unchanged"
+    );
+
+    // Check that Div is added correctly
+    assert.deepEqual(
+      mergedResults.Div,
+      ["width", "padding"],
+      "Div props should be added to the merged results"
+    );
   });
 });


### PR DESCRIPTION
This PR add the analyze feature to fetch all the use Orbiter components and their poroperties.
```bash
npx codemod workleap/orbiter-to-hopper -a -n 1
```

The output example: `orbiter-usage.json`
```
  "Img": [
    "data-public",
    "height",
    "width",
    "marginRight",
    "borderRadius",
    "alt",
    "src"
  ],
  "TextArea": [
    "autoFocus",
    "fluid",
    "rows",
    "resize",
    "placeholder",
    "value",
    "onChange"
  ],
  "Section": [
    "title"
  ],
"Box": [
    "borderRadius",
    "padding",
    "key",
    "role",
    "aria-describedby",
    "aria-label",
    "aria-labelledby",
    "aria-modal",
    "ref",
    "tabIndex",
    "className",
    "overflowY",
    "as",
    "border",
    "marginBottom"
  ],
```

