### PR TITLE
feat: restructure AnalysisResults interface to nested format with ove…

### DIFF
--- a/.codemodrc.json
+++ b/.codemodrc.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://codemod-utils.s3.us-west-1.amazonaws.com/configuration_schema.json",
   "name": "workleap/orbiter-to-hopper",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "engine": "jscodeshift",
   "private": false,
   "arguments": [

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,2 @@
+- When creating a PR:
+- Make sure to update the version in the `.codemodrc.json` file. Just increment the minor version.

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ codemod --source /path/to/your/local/copy
 > [!TIP]
 > To run the latest modifications, the `cdmd_dist` folder should not exist. If you use the `pnpm deploy:codemod`, this folder is getting deleted after each deployment automatically.
 
-### Simple Modifications
+### Mappings Modifications
 
 Modify the [mappings.ts](/src/mappings/mappings.ts) for simple mappings. Just add the components and props to map.
 
@@ -155,3 +155,8 @@ Modify the [mappings.ts](/src/mappings/mappings.ts) for simple mappings. Just ad
   },
 };
 ```
+
+There are some [helper functions](/src/mappings/helpers.ts) that can help you write mappings more easily:
+
+- `createPropertyMapper`: A generic method to create mapping for properties.
+- `createCssPropertyMapper`: To create map for styled system properties between Orbiter and Hopper.

--- a/src/mappings/styled-system/styles/alignments.ts
+++ b/src/mappings/styled-system/styles/alignments.ts
@@ -1,8 +1,8 @@
-import { createStyleMapper } from "../../helpers.js";
+import { createCssPropertyMapper } from "../../helpers.js";
 
-export const alignContentMapper = createStyleMapper({
+export const alignContentMapper = createCssPropertyMapper({
   propertyName: "alignContent",
-  extraGlobalValues: [
+  validGlobalValues: [
     "center",
     "start",
     "end",
@@ -17,9 +17,9 @@ export const alignContentMapper = createStyleMapper({
   ],
 });
 
-export const alignItemsMapper = createStyleMapper({
+export const alignItemsMapper = createCssPropertyMapper({
   propertyName: "alignItems",
-  extraGlobalValues: [
+  validGlobalValues: [
     "center",
     "start",
     "end",
@@ -31,9 +31,9 @@ export const alignItemsMapper = createStyleMapper({
   ],
 });
 
-export const alignSelfMapper = createStyleMapper({
+export const alignSelfMapper = createCssPropertyMapper({
   propertyName: "alignSelf",
-  extraGlobalValues: [
+  validGlobalValues: [
     "auto",
     "center",
     "start",

--- a/src/mappings/styled-system/styles/borderRadius.ts
+++ b/src/mappings/styled-system/styles/borderRadius.ts
@@ -1,44 +1,44 @@
-import { createStyleMapper } from "../../helpers.js";
+import { createCssPropertyMapper } from "../../helpers.js";
 
 import { BorderRadiusMapping as HopperBorderRadiusMapping } from "@hopper-ui/components";
 import { BorderRadiusMapping as OrbiterBorderRadiusMapping } from "@workleap/orbiter-ui";
 
-export const borderRadiusMapper = createStyleMapper({
+export const borderRadiusMapper = createCssPropertyMapper({
   propertyName: "borderRadius",
   unsafePropertyName: "UNSAFE_borderRadius",
-  extraGlobalValues: [0],
-  orbiterValidKeys: OrbiterBorderRadiusMapping,
-  hopperValidKeys: HopperBorderRadiusMapping,
+  validGlobalValues: [0],
+  sourceValidKeys: OrbiterBorderRadiusMapping,
+  targetValidKeys: HopperBorderRadiusMapping,
 });
 
-export const borderTopLeftRadiusMapper = createStyleMapper({
+export const borderTopLeftRadiusMapper = createCssPropertyMapper({
   propertyName: "borderTopLeftRadius",
   unsafePropertyName: "UNSAFE_borderTopLeftRadius",
-  extraGlobalValues: [0],
-  orbiterValidKeys: OrbiterBorderRadiusMapping,
-  hopperValidKeys: HopperBorderRadiusMapping,
+  validGlobalValues: [0],
+  sourceValidKeys: OrbiterBorderRadiusMapping,
+  targetValidKeys: HopperBorderRadiusMapping,
 });
 
-export const borderTopRightRadiusMapper = createStyleMapper({
+export const borderTopRightRadiusMapper = createCssPropertyMapper({
   propertyName: "borderTopRightRadius",
   unsafePropertyName: "UNSAFE_borderTopRightRadius",
-  extraGlobalValues: [0],
-  orbiterValidKeys: OrbiterBorderRadiusMapping,
-  hopperValidKeys: HopperBorderRadiusMapping,
+  validGlobalValues: [0],
+  sourceValidKeys: OrbiterBorderRadiusMapping,
+  targetValidKeys: HopperBorderRadiusMapping,
 });
 
-export const borderBottomLeftRadiusMapper = createStyleMapper({
+export const borderBottomLeftRadiusMapper = createCssPropertyMapper({
   propertyName: "borderBottomLeftRadius",
   unsafePropertyName: "UNSAFE_borderBottomLeftRadius",
-  extraGlobalValues: [0],
-  orbiterValidKeys: OrbiterBorderRadiusMapping,
-  hopperValidKeys: HopperBorderRadiusMapping,
+  validGlobalValues: [0],
+  sourceValidKeys: OrbiterBorderRadiusMapping,
+  targetValidKeys: HopperBorderRadiusMapping,
 });
 
-export const borderBottomRightRadiusMapper = createStyleMapper({
+export const borderBottomRightRadiusMapper = createCssPropertyMapper({
   propertyName: "borderBottomRightRadius",
   unsafePropertyName: "UNSAFE_borderBottomRightRadius",
-  extraGlobalValues: [0],
-  orbiterValidKeys: OrbiterBorderRadiusMapping,
-  hopperValidKeys: HopperBorderRadiusMapping,
+  validGlobalValues: [0],
+  sourceValidKeys: OrbiterBorderRadiusMapping,
+  targetValidKeys: HopperBorderRadiusMapping,
 });

--- a/src/mappings/styled-system/styles/borders.ts
+++ b/src/mappings/styled-system/styles/borders.ts
@@ -1,164 +1,164 @@
-import { createStyleMapper } from "../../helpers.js";
+import { createCssPropertyMapper } from "../../helpers.js";
 
 import { BorderMapping as HopperBorderMapping } from "@hopper-ui/components";
 import { BorderMapping as OrbiterBorderMapping } from "@workleap/orbiter-ui";
 
-export const borderMapper = createStyleMapper({
+export const borderMapper = createCssPropertyMapper({
   propertyName: "border",
   unsafePropertyName: "UNSAFE_border",
-  extraGlobalValues: ["currentcolor", "transparent", 0],
-  orbiterValidKeys: OrbiterBorderMapping,
-  hopperValidKeys: HopperBorderMapping,
+  validGlobalValues: ["currentcolor", "transparent", 0],
+  sourceValidKeys: OrbiterBorderMapping,
+  targetValidKeys: HopperBorderMapping,
 });
 
-export const borderActiveMapper = createStyleMapper({
+export const borderActiveMapper = createCssPropertyMapper({
   propertyName: "borderActive",
   unsafePropertyName: "UNSAFE_borderActive",
-  extraGlobalValues: ["currentcolor", "transparent", 0],
-  orbiterValidKeys: OrbiterBorderMapping,
-  hopperValidKeys: HopperBorderMapping,
+  validGlobalValues: ["currentcolor", "transparent", 0],
+  sourceValidKeys: OrbiterBorderMapping,
+  targetValidKeys: HopperBorderMapping,
 });
 
-export const borderFocusMapper = createStyleMapper({
+export const borderFocusMapper = createCssPropertyMapper({
   propertyName: "borderFocus",
   unsafePropertyName: "UNSAFE_borderFocus",
-  extraGlobalValues: ["currentcolor", "transparent", 0],
-  orbiterValidKeys: OrbiterBorderMapping,
-  hopperValidKeys: HopperBorderMapping,
+  validGlobalValues: ["currentcolor", "transparent", 0],
+  sourceValidKeys: OrbiterBorderMapping,
+  targetValidKeys: HopperBorderMapping,
 });
 
-export const borderHoverMapper = createStyleMapper({
+export const borderHoverMapper = createCssPropertyMapper({
   propertyName: "borderHover",
   unsafePropertyName: "UNSAFE_borderHover",
-  extraGlobalValues: ["currentcolor", "transparent", 0],
-  orbiterValidKeys: OrbiterBorderMapping,
-  hopperValidKeys: HopperBorderMapping,
+  validGlobalValues: ["currentcolor", "transparent", 0],
+  sourceValidKeys: OrbiterBorderMapping,
+  targetValidKeys: HopperBorderMapping,
 });
 
-export const borderBottomMapper = createStyleMapper({
+export const borderBottomMapper = createCssPropertyMapper({
   propertyName: "borderBottom",
   unsafePropertyName: "UNSAFE_borderBottom",
-  extraGlobalValues: ["currentcolor", "transparent", 0],
-  orbiterValidKeys: OrbiterBorderMapping,
-  hopperValidKeys: HopperBorderMapping,
+  validGlobalValues: ["currentcolor", "transparent", 0],
+  sourceValidKeys: OrbiterBorderMapping,
+  targetValidKeys: HopperBorderMapping,
 });
 
-export const borderBottomActiveMapper = createStyleMapper({
+export const borderBottomActiveMapper = createCssPropertyMapper({
   propertyName: "borderBottomActive",
   unsafePropertyName: "UNSAFE_borderBottomActive",
-  extraGlobalValues: ["currentcolor", "transparent", 0],
-  orbiterValidKeys: OrbiterBorderMapping,
-  hopperValidKeys: HopperBorderMapping,
+  validGlobalValues: ["currentcolor", "transparent", 0],
+  sourceValidKeys: OrbiterBorderMapping,
+  targetValidKeys: HopperBorderMapping,
 });
 
-export const borderBottomFocusMapper = createStyleMapper({
+export const borderBottomFocusMapper = createCssPropertyMapper({
   propertyName: "borderBottomFocus",
   unsafePropertyName: "UNSAFE_borderBottomFocus",
-  extraGlobalValues: ["currentcolor", "transparent", 0],
-  orbiterValidKeys: OrbiterBorderMapping,
-  hopperValidKeys: HopperBorderMapping,
+  validGlobalValues: ["currentcolor", "transparent", 0],
+  sourceValidKeys: OrbiterBorderMapping,
+  targetValidKeys: HopperBorderMapping,
 });
 
-export const borderBottomHoverMapper = createStyleMapper({
+export const borderBottomHoverMapper = createCssPropertyMapper({
   propertyName: "borderBottomHover",
   unsafePropertyName: "UNSAFE_borderBottomHover",
-  extraGlobalValues: ["currentcolor", "transparent", 0],
-  orbiterValidKeys: OrbiterBorderMapping,
-  hopperValidKeys: HopperBorderMapping,
+  validGlobalValues: ["currentcolor", "transparent", 0],
+  sourceValidKeys: OrbiterBorderMapping,
+  targetValidKeys: HopperBorderMapping,
 });
 
-export const borderLeftMapper = createStyleMapper({
+export const borderLeftMapper = createCssPropertyMapper({
   propertyName: "borderLeft",
   unsafePropertyName: "UNSAFE_borderLeft",
-  extraGlobalValues: ["currentcolor", "transparent", 0],
-  orbiterValidKeys: OrbiterBorderMapping,
-  hopperValidKeys: HopperBorderMapping,
+  validGlobalValues: ["currentcolor", "transparent", 0],
+  sourceValidKeys: OrbiterBorderMapping,
+  targetValidKeys: HopperBorderMapping,
 });
 
-export const borderLeftActiveMapper = createStyleMapper({
+export const borderLeftActiveMapper = createCssPropertyMapper({
   propertyName: "borderLeftActive",
   unsafePropertyName: "UNSAFE_borderLeftActive",
-  extraGlobalValues: ["currentcolor", "transparent", 0],
-  orbiterValidKeys: OrbiterBorderMapping,
-  hopperValidKeys: HopperBorderMapping,
+  validGlobalValues: ["currentcolor", "transparent", 0],
+  sourceValidKeys: OrbiterBorderMapping,
+  targetValidKeys: HopperBorderMapping,
 });
 
-export const borderLeftFocusMapper = createStyleMapper({
+export const borderLeftFocusMapper = createCssPropertyMapper({
   propertyName: "borderLeftFocus",
   unsafePropertyName: "UNSAFE_borderLeftFocus",
-  extraGlobalValues: ["currentcolor", "transparent", 0],
-  orbiterValidKeys: OrbiterBorderMapping,
-  hopperValidKeys: HopperBorderMapping,
+  validGlobalValues: ["currentcolor", "transparent", 0],
+  sourceValidKeys: OrbiterBorderMapping,
+  targetValidKeys: HopperBorderMapping,
 });
 
-export const borderLeftHoverMapper = createStyleMapper({
+export const borderLeftHoverMapper = createCssPropertyMapper({
   propertyName: "borderLeftHover",
   unsafePropertyName: "UNSAFE_borderLeftHover",
-  extraGlobalValues: ["currentcolor", "transparent", 0],
-  orbiterValidKeys: OrbiterBorderMapping,
-  hopperValidKeys: HopperBorderMapping,
+  validGlobalValues: ["currentcolor", "transparent", 0],
+  sourceValidKeys: OrbiterBorderMapping,
+  targetValidKeys: HopperBorderMapping,
 });
 
-export const borderRightMapper = createStyleMapper({
+export const borderRightMapper = createCssPropertyMapper({
   propertyName: "borderRight",
   unsafePropertyName: "UNSAFE_borderRight",
-  extraGlobalValues: ["currentcolor", "transparent", 0],
-  orbiterValidKeys: OrbiterBorderMapping,
-  hopperValidKeys: HopperBorderMapping,
+  validGlobalValues: ["currentcolor", "transparent", 0],
+  sourceValidKeys: OrbiterBorderMapping,
+  targetValidKeys: HopperBorderMapping,
 });
 
-export const borderRightActiveMapper = createStyleMapper({
+export const borderRightActiveMapper = createCssPropertyMapper({
   propertyName: "borderRightActive",
   unsafePropertyName: "UNSAFE_borderRightActive",
-  extraGlobalValues: ["currentcolor", "transparent", 0],
-  orbiterValidKeys: OrbiterBorderMapping,
-  hopperValidKeys: HopperBorderMapping,
+  validGlobalValues: ["currentcolor", "transparent", 0],
+  sourceValidKeys: OrbiterBorderMapping,
+  targetValidKeys: HopperBorderMapping,
 });
 
-export const borderRightFocusMapper = createStyleMapper({
+export const borderRightFocusMapper = createCssPropertyMapper({
   propertyName: "borderRightFocus",
   unsafePropertyName: "UNSAFE_borderRightFocus",
-  extraGlobalValues: ["currentcolor", "transparent", 0],
-  orbiterValidKeys: OrbiterBorderMapping,
-  hopperValidKeys: HopperBorderMapping,
+  validGlobalValues: ["currentcolor", "transparent", 0],
+  sourceValidKeys: OrbiterBorderMapping,
+  targetValidKeys: HopperBorderMapping,
 });
 
-export const borderRightHoverMapper = createStyleMapper({
+export const borderRightHoverMapper = createCssPropertyMapper({
   propertyName: "borderRightHover",
   unsafePropertyName: "UNSAFE_borderRightHover",
-  extraGlobalValues: ["currentcolor", "transparent", 0],
-  orbiterValidKeys: OrbiterBorderMapping,
-  hopperValidKeys: HopperBorderMapping,
+  validGlobalValues: ["currentcolor", "transparent", 0],
+  sourceValidKeys: OrbiterBorderMapping,
+  targetValidKeys: HopperBorderMapping,
 });
 
-export const borderTopMapper = createStyleMapper({
+export const borderTopMapper = createCssPropertyMapper({
   propertyName: "borderTop",
   unsafePropertyName: "UNSAFE_borderTop",
-  extraGlobalValues: ["currentcolor", "transparent", 0],
-  orbiterValidKeys: OrbiterBorderMapping,
-  hopperValidKeys: HopperBorderMapping,
+  validGlobalValues: ["currentcolor", "transparent", 0],
+  sourceValidKeys: OrbiterBorderMapping,
+  targetValidKeys: HopperBorderMapping,
 });
 
-export const borderTopActiveMapper = createStyleMapper({
+export const borderTopActiveMapper = createCssPropertyMapper({
   propertyName: "borderTopActive",
   unsafePropertyName: "UNSAFE_borderTopActive",
-  extraGlobalValues: ["currentcolor", "transparent", 0],
-  orbiterValidKeys: OrbiterBorderMapping,
-  hopperValidKeys: HopperBorderMapping,
+  validGlobalValues: ["currentcolor", "transparent", 0],
+  sourceValidKeys: OrbiterBorderMapping,
+  targetValidKeys: HopperBorderMapping,
 });
 
-export const borderTopFocusMapper = createStyleMapper({
+export const borderTopFocusMapper = createCssPropertyMapper({
   propertyName: "borderTopFocus",
   unsafePropertyName: "UNSAFE_borderTopFocus",
-  extraGlobalValues: ["currentcolor", "transparent", 0],
-  orbiterValidKeys: OrbiterBorderMapping,
-  hopperValidKeys: HopperBorderMapping,
+  validGlobalValues: ["currentcolor", "transparent", 0],
+  sourceValidKeys: OrbiterBorderMapping,
+  targetValidKeys: HopperBorderMapping,
 });
 
-export const borderTopHoverMapper = createStyleMapper({
+export const borderTopHoverMapper = createCssPropertyMapper({
   propertyName: "borderTopHover",
   unsafePropertyName: "UNSAFE_borderTopHover",
-  extraGlobalValues: ["currentcolor", "transparent", 0],
-  orbiterValidKeys: OrbiterBorderMapping,
-  hopperValidKeys: HopperBorderMapping,
+  validGlobalValues: ["currentcolor", "transparent", 0],
+  sourceValidKeys: OrbiterBorderMapping,
+  targetValidKeys: HopperBorderMapping,
 });

--- a/src/mappings/styled-system/styles/boxShadow.ts
+++ b/src/mappings/styled-system/styles/boxShadow.ts
@@ -1,36 +1,36 @@
-import { createStyleMapper } from "../../helpers.ts";
+import { createCssPropertyMapper } from "../../helpers.ts";
 
 import { BoxShadowMapping as HopperBoxShadowMapping } from "@hopper-ui/components";
 import { BoxShadowMapping as OrbiterBoxShadowMapping } from "@workleap/orbiter-ui";
 
-export const boxShadowMapper = createStyleMapper({
+export const boxShadowMapper = createCssPropertyMapper({
   propertyName: "boxShadow",
   unsafePropertyName: "UNSAFE_boxShadow",
-  extraGlobalValues: ["none"],
-  orbiterValidKeys: OrbiterBoxShadowMapping,
-  hopperValidKeys: HopperBoxShadowMapping,
+  validGlobalValues: ["none"],
+  sourceValidKeys: OrbiterBoxShadowMapping,
+  targetValidKeys: HopperBoxShadowMapping,
 });
 
-export const boxShadowActiveMapper = createStyleMapper({
+export const boxShadowActiveMapper = createCssPropertyMapper({
   propertyName: "boxShadowActive",
   unsafePropertyName: "UNSAFE_boxShadowActive",
-  extraGlobalValues: ["none"],
-  orbiterValidKeys: OrbiterBoxShadowMapping,
-  hopperValidKeys: HopperBoxShadowMapping,
+  validGlobalValues: ["none"],
+  sourceValidKeys: OrbiterBoxShadowMapping,
+  targetValidKeys: HopperBoxShadowMapping,
 });
 
-export const boxShadowFocusMapper = createStyleMapper({
+export const boxShadowFocusMapper = createCssPropertyMapper({
   propertyName: "boxShadowFocus",
   unsafePropertyName: "UNSAFE_boxShadowFocus",
-  extraGlobalValues: ["none"],
-  orbiterValidKeys: OrbiterBoxShadowMapping,
-  hopperValidKeys: HopperBoxShadowMapping,
+  validGlobalValues: ["none"],
+  sourceValidKeys: OrbiterBoxShadowMapping,
+  targetValidKeys: HopperBoxShadowMapping,
 });
 
-export const boxShadowHoverMapper = createStyleMapper({
+export const boxShadowHoverMapper = createCssPropertyMapper({
   propertyName: "boxShadowHover",
   unsafePropertyName: "UNSAFE_boxShadowHover",
-  extraGlobalValues: ["none"],
-  orbiterValidKeys: OrbiterBoxShadowMapping,
-  hopperValidKeys: HopperBoxShadowMapping,
+  validGlobalValues: ["none"],
+  sourceValidKeys: OrbiterBoxShadowMapping,
+  targetValidKeys: HopperBoxShadowMapping,
 });

--- a/src/mappings/styled-system/styles/colors.ts
+++ b/src/mappings/styled-system/styles/colors.ts
@@ -1,4 +1,4 @@
-import { createStyleMapper } from "../../helpers.js";
+import { createCssPropertyMapper } from "../../helpers.js";
 import { HopperStyledSystemPropsKeys } from "../types.js";
 
 import {
@@ -11,67 +11,67 @@ import {
 } from "@workleap/orbiter-ui";
 
 // Text color mappers
-export const colorMapper = createStyleMapper({
+export const colorMapper = createCssPropertyMapper({
   propertyName: "color",
   unsafePropertyName: "UNSAFE_color",
-  extraGlobalValues: ["currentcolor"],
-  orbiterValidKeys: OrbiterTextColorMapping,
-  hopperValidKeys: HopperTextColorMapping,
+  validGlobalValues: ["currentcolor"],
+  sourceValidKeys: OrbiterTextColorMapping,
+  targetValidKeys: HopperTextColorMapping,
 });
 
-export const colorActiveMapper = createStyleMapper({
+export const colorActiveMapper = createCssPropertyMapper({
   propertyName: "colorActive",
   unsafePropertyName: "UNSAFE_colorActive",
-  extraGlobalValues: ["currentcolor"],
-  orbiterValidKeys: OrbiterTextColorMapping,
-  hopperValidKeys: HopperTextColorMapping,
+  validGlobalValues: ["currentcolor"],
+  sourceValidKeys: OrbiterTextColorMapping,
+  targetValidKeys: HopperTextColorMapping,
 });
 
-export const colorFocusMapper = createStyleMapper({
+export const colorFocusMapper = createCssPropertyMapper({
   propertyName: "colorFocus",
   unsafePropertyName: "UNSAFE_colorFocus",
-  extraGlobalValues: ["currentcolor"],
-  orbiterValidKeys: OrbiterTextColorMapping,
-  hopperValidKeys: HopperTextColorMapping,
+  validGlobalValues: ["currentcolor"],
+  sourceValidKeys: OrbiterTextColorMapping,
+  targetValidKeys: HopperTextColorMapping,
 });
 
-export const colorHoverMapper = createStyleMapper({
+export const colorHoverMapper = createCssPropertyMapper({
   propertyName: "colorHover",
   unsafePropertyName: "UNSAFE_colorHover",
-  extraGlobalValues: ["currentcolor"],
-  orbiterValidKeys: OrbiterTextColorMapping,
-  hopperValidKeys: HopperTextColorMapping,
+  validGlobalValues: ["currentcolor"],
+  sourceValidKeys: OrbiterTextColorMapping,
+  targetValidKeys: HopperTextColorMapping,
 });
 
 // Background color mappers
-export const backgroundColorMapper = createStyleMapper({
+export const backgroundColorMapper = createCssPropertyMapper({
   propertyName: "backgroundColor",
   unsafePropertyName: "UNSAFE_backgroundColor",
-  extraGlobalValues: ["currentcolor"],
-  orbiterValidKeys: OrbiterBackgroundColorMapping,
-  hopperValidKeys: HopperBackgroundColorMapping,
+  validGlobalValues: ["currentcolor"],
+  sourceValidKeys: OrbiterBackgroundColorMapping,
+  targetValidKeys: HopperBackgroundColorMapping,
 });
 
-export const backgroundColorActiveMapper = createStyleMapper({
+export const backgroundColorActiveMapper = createCssPropertyMapper({
   propertyName: "backgroundColorActive",
   unsafePropertyName: "UNSAFE_backgroundColorActive",
-  extraGlobalValues: ["currentcolor"],
-  orbiterValidKeys: OrbiterBackgroundColorMapping,
-  hopperValidKeys: HopperBackgroundColorMapping,
+  validGlobalValues: ["currentcolor"],
+  sourceValidKeys: OrbiterBackgroundColorMapping,
+  targetValidKeys: HopperBackgroundColorMapping,
 });
 
-export const backgroundColorFocusMapper = createStyleMapper({
+export const backgroundColorFocusMapper = createCssPropertyMapper({
   propertyName: "backgroundColorFocus",
   unsafePropertyName: "UNSAFE_backgroundColorFocus",
-  extraGlobalValues: ["currentcolor"],
-  orbiterValidKeys: OrbiterBackgroundColorMapping,
-  hopperValidKeys: HopperBackgroundColorMapping,
+  validGlobalValues: ["currentcolor"],
+  sourceValidKeys: OrbiterBackgroundColorMapping,
+  targetValidKeys: HopperBackgroundColorMapping,
 });
 
-export const backgroundColorHoverMapper = createStyleMapper({
+export const backgroundColorHoverMapper = createCssPropertyMapper({
   propertyName: "backgroundColorHover",
   unsafePropertyName: "UNSAFE_backgroundColorHover",
-  extraGlobalValues: ["currentcolor"],
-  orbiterValidKeys: OrbiterBackgroundColorMapping,
-  hopperValidKeys: HopperBackgroundColorMapping,
+  validGlobalValues: ["currentcolor"],
+  sourceValidKeys: OrbiterBackgroundColorMapping,
+  targetValidKeys: HopperBackgroundColorMapping,
 });

--- a/src/mappings/styled-system/styles/fill.ts
+++ b/src/mappings/styled-system/styles/fill.ts
@@ -1,36 +1,36 @@
-import { createStyleMapper } from "../../helpers.ts";
+import { createCssPropertyMapper } from "../../helpers.ts";
 
 import { IconColorMapping as HopperIconColorMapping } from "@hopper-ui/components";
 import { IconColorMapping as OrbiterIconColorMapping } from "@workleap/orbiter-ui";
 
-export const fillMapper = createStyleMapper({
+export const fillMapper = createCssPropertyMapper({
   propertyName: "fill",
   unsafePropertyName: "UNSAFE_fill",
-  extraGlobalValues: ["child", "context-fill", "context-stroke", "none"],
-  orbiterValidKeys: OrbiterIconColorMapping,
-  hopperValidKeys: HopperIconColorMapping,
+  validGlobalValues: ["child", "context-fill", "context-stroke", "none"],
+  sourceValidKeys: OrbiterIconColorMapping,
+  targetValidKeys: HopperIconColorMapping,
 });
 
-export const fillHoverMapper = createStyleMapper({
+export const fillHoverMapper = createCssPropertyMapper({
   propertyName: "fillHover",
   unsafePropertyName: "UNSAFE_fillHover",
-  extraGlobalValues: ["child", "context-fill", "context-stroke", "none"],
-  orbiterValidKeys: OrbiterIconColorMapping,
-  hopperValidKeys: HopperIconColorMapping,
+  validGlobalValues: ["child", "context-fill", "context-stroke", "none"],
+  sourceValidKeys: OrbiterIconColorMapping,
+  targetValidKeys: HopperIconColorMapping,
 });
 
-export const fillFocusMapper = createStyleMapper({
+export const fillFocusMapper = createCssPropertyMapper({
   propertyName: "fillFocus",
   unsafePropertyName: "UNSAFE_fillFocus",
-  extraGlobalValues: ["child", "context-fill", "context-stroke", "none"],
-  orbiterValidKeys: OrbiterIconColorMapping,
-  hopperValidKeys: HopperIconColorMapping,
+  validGlobalValues: ["child", "context-fill", "context-stroke", "none"],
+  sourceValidKeys: OrbiterIconColorMapping,
+  targetValidKeys: HopperIconColorMapping,
 });
 
-export const strokeFocusMapper = createStyleMapper({
+export const strokeFocusMapper = createCssPropertyMapper({
   propertyName: "stroke",
   unsafePropertyName: "UNSAFE_stroke",
-  extraGlobalValues: [
+  validGlobalValues: [
     "child",
     "context-fill",
     "context-stroke",
@@ -38,6 +38,6 @@ export const strokeFocusMapper = createStyleMapper({
     "currentcolor",
     "transparent",
   ],
-  orbiterValidKeys: OrbiterIconColorMapping,
-  hopperValidKeys: HopperIconColorMapping,
+  sourceValidKeys: OrbiterIconColorMapping,
+  targetValidKeys: HopperIconColorMapping,
 });

--- a/src/mappings/styled-system/styles/fonts.ts
+++ b/src/mappings/styled-system/styles/fonts.ts
@@ -1,4 +1,4 @@
-import { createStyleMapper } from "../../helpers.js";
+import { createCssPropertyMapper } from "../../helpers.js";
 
 import {
   FontFamilyMapping as HopperFontFamilyMapping,
@@ -11,19 +11,19 @@ import {
   FontWeightMapping as OrbiterFontWeightMapping,
 } from "@workleap/orbiter-ui";
 
-export const fontFamilyMapper = createStyleMapper({
+export const fontFamilyMapper = createCssPropertyMapper({
   propertyName: "fontFamily",
   unsafePropertyName: "UNSAFE_fontFamily",
-  orbiterValidKeys: OrbiterFontFamilyMapping,
-  hopperValidKeys: HopperFontFamilyMapping,
+  sourceValidKeys: OrbiterFontFamilyMapping,
+  targetValidKeys: HopperFontFamilyMapping,
 });
 
-export const fontSizeMapper = createStyleMapper({
+export const fontSizeMapper = createCssPropertyMapper({
   propertyName: "fontSize",
   unsafePropertyName: "UNSAFE_fontSize",
-  extraGlobalValues: [],
-  orbiterValidKeys: OrbiterFontSizeMapping,
-  hopperValidKeys: HopperFontSizeMapping,
+  validGlobalValues: [],
+  sourceValidKeys: OrbiterFontSizeMapping,
+  targetValidKeys: HopperFontSizeMapping,
   customMapper: (value, _, { j }) => {
     if (typeof value === "number") {
       return {
@@ -35,14 +35,14 @@ export const fontSizeMapper = createStyleMapper({
   },
 });
 
-export const fontStyleMapper = createStyleMapper({
+export const fontStyleMapper = createCssPropertyMapper({
   propertyName: "fontStyle",
-  extraGlobalValues: ["normal", "italic", "oblique"],
+  validGlobalValues: ["normal", "italic", "oblique"],
 });
 
-export const fontWeightMapper = createStyleMapper({
+export const fontWeightMapper = createCssPropertyMapper({
   propertyName: "fontWeight",
   unsafePropertyName: "UNSAFE_fontWeight",
-  hopperValidKeys: HopperFontWeightMapping,
-  orbiterValidKeys: OrbiterFontWeightMapping,
+  targetValidKeys: HopperFontWeightMapping,
+  sourceValidKeys: OrbiterFontWeightMapping,
 });

--- a/src/mappings/styled-system/styles/gap.ts
+++ b/src/mappings/styled-system/styles/gap.ts
@@ -1,28 +1,28 @@
-import { createStyleMapper } from "../../helpers.js";
+import { createCssPropertyMapper } from "../../helpers.js";
 
 import { SimpleMarginMapping as HopperSimpleMarginMapping } from "@hopper-ui/components";
 import { SimpleMarginMapping as OrbiterSimpleMarginMapping } from "@workleap/orbiter-ui";
 
-export const gapMapper = createStyleMapper({
+export const gapMapper = createCssPropertyMapper({
   propertyName: "gap",
   unsafePropertyName: "UNSAFE_gap",
-  extraGlobalValues: ["normal", "0"],
-  orbiterValidKeys: OrbiterSimpleMarginMapping,
-  hopperValidKeys: HopperSimpleMarginMapping,
+  validGlobalValues: ["normal", "0"],
+  sourceValidKeys: OrbiterSimpleMarginMapping,
+  targetValidKeys: HopperSimpleMarginMapping,
 });
 
-export const rowGapMapper = createStyleMapper({
+export const rowGapMapper = createCssPropertyMapper({
   propertyName: "rowGap",
   unsafePropertyName: "UNSAFE_rowGap",
-  extraGlobalValues: ["normal", "0"],
-  orbiterValidKeys: OrbiterSimpleMarginMapping,
-  hopperValidKeys: HopperSimpleMarginMapping,
+  validGlobalValues: ["normal", "0"],
+  sourceValidKeys: OrbiterSimpleMarginMapping,
+  targetValidKeys: HopperSimpleMarginMapping,
 });
 
-export const columnGapMapper = createStyleMapper({
+export const columnGapMapper = createCssPropertyMapper({
   propertyName: "columnGap",
   unsafePropertyName: "UNSAFE_columnGap",
-  extraGlobalValues: ["normal", "0"],
-  orbiterValidKeys: OrbiterSimpleMarginMapping,
-  hopperValidKeys: HopperSimpleMarginMapping,
+  validGlobalValues: ["normal", "0"],
+  sourceValidKeys: OrbiterSimpleMarginMapping,
+  targetValidKeys: HopperSimpleMarginMapping,
 });

--- a/src/mappings/styled-system/styles/grid.ts
+++ b/src/mappings/styled-system/styles/grid.ts
@@ -1,5 +1,5 @@
 import {
-  createStyleMapper,
+  createCssPropertyMapper,
   isFrValue,
   isPercentageValue,
 } from "../../helpers.js";
@@ -7,12 +7,12 @@ import {
 import { SizingMapping as HopperSizingMapping } from "@hopper-ui/components";
 import { SizingMapping as OrbiterSizingMapping } from "@workleap/orbiter-ui";
 
-export const gridAutoColumnsMapper = createStyleMapper({
+export const gridAutoColumnsMapper = createCssPropertyMapper({
   propertyName: "gridAutoColumns",
   unsafePropertyName: "UNSAFE_gridAutoColumns",
-  extraGlobalValues: ["auto", "min-content", "max-content"],
-  orbiterValidKeys: OrbiterSizingMapping,
-  hopperValidKeys: HopperSizingMapping,
+  validGlobalValues: ["auto", "min-content", "max-content"],
+  sourceValidKeys: OrbiterSizingMapping,
+  targetValidKeys: HopperSizingMapping,
   customMapper: (value, originalValue) => {
     if (isPercentageValue(value) || isFrValue(value)) {
       return {
@@ -24,12 +24,12 @@ export const gridAutoColumnsMapper = createStyleMapper({
   },
 });
 
-export const gridAutoRowsMapper = createStyleMapper({
+export const gridAutoRowsMapper = createCssPropertyMapper({
   propertyName: "gridAutoRows",
   unsafePropertyName: "UNSAFE_gridAutoRows",
-  extraGlobalValues: ["auto", "min-content", "max-content"],
-  orbiterValidKeys: OrbiterSizingMapping,
-  hopperValidKeys: HopperSizingMapping,
+  validGlobalValues: ["auto", "min-content", "max-content"],
+  sourceValidKeys: OrbiterSizingMapping,
+  targetValidKeys: HopperSizingMapping,
   customMapper: (value, originalValue) => {
     if (isPercentageValue(value) || isFrValue(value)) {
       return {
@@ -41,12 +41,12 @@ export const gridAutoRowsMapper = createStyleMapper({
   },
 });
 
-export const gridTemplateColumnsMapper = createStyleMapper({
+export const gridTemplateColumnsMapper = createCssPropertyMapper({
   propertyName: "gridTemplateColumns",
   unsafePropertyName: "UNSAFE_gridTemplateColumns",
-  extraGlobalValues: ["none", "subgrid", "auto", "max-content", "min-content"],
-  orbiterValidKeys: OrbiterSizingMapping,
-  hopperValidKeys: HopperSizingMapping,
+  validGlobalValues: ["none", "subgrid", "auto", "max-content", "min-content"],
+  sourceValidKeys: OrbiterSizingMapping,
+  targetValidKeys: HopperSizingMapping,
   customMapper: (value, originalValue) => {
     if (isPercentageValue(value) || isFrValue(value)) {
       return {
@@ -57,12 +57,12 @@ export const gridTemplateColumnsMapper = createStyleMapper({
     return null;
   },
 });
-export const gridTemplateRowsMapper = createStyleMapper({
+export const gridTemplateRowsMapper = createCssPropertyMapper({
   propertyName: "gridTemplateRows",
   unsafePropertyName: "UNSAFE_gridTemplateRows",
-  extraGlobalValues: ["none", "subgrid", "auto", "max-content", "min-content"],
-  orbiterValidKeys: OrbiterSizingMapping,
-  hopperValidKeys: HopperSizingMapping,
+  validGlobalValues: ["none", "subgrid", "auto", "max-content", "min-content"],
+  sourceValidKeys: OrbiterSizingMapping,
+  targetValidKeys: HopperSizingMapping,
   customMapper: (value, originalValue) => {
     if (isPercentageValue(value) || isFrValue(value)) {
       return {

--- a/src/mappings/styled-system/styles/justify.ts
+++ b/src/mappings/styled-system/styles/justify.ts
@@ -1,8 +1,8 @@
-import { createStyleMapper } from "../../helpers.js";
+import { createCssPropertyMapper } from "../../helpers.js";
 
-export const justifyContentMapper = createStyleMapper({
+export const justifyContentMapper = createCssPropertyMapper({
   propertyName: "justifyContent",
-  extraGlobalValues: [
+  validGlobalValues: [
     "center",
     "start",
     "end",
@@ -18,9 +18,9 @@ export const justifyContentMapper = createStyleMapper({
   ],
 });
 
-export const justifyItemsMapper = createStyleMapper({
+export const justifyItemsMapper = createCssPropertyMapper({
   propertyName: "justifyItems",
-  extraGlobalValues: [
+  validGlobalValues: [
     "normal",
     "stretch",
     "center",
@@ -37,9 +37,9 @@ export const justifyItemsMapper = createStyleMapper({
   ],
 });
 
-export const justifySelfMapper = createStyleMapper({
+export const justifySelfMapper = createCssPropertyMapper({
   propertyName: "justifySelf",
-  extraGlobalValues: [
+  validGlobalValues: [
     "auto",
     "normal",
     "stretch",

--- a/src/mappings/styled-system/styles/margins.ts
+++ b/src/mappings/styled-system/styles/margins.ts
@@ -1,4 +1,4 @@
-import { createStyleMapper } from "../../helpers.js";
+import { createCssPropertyMapper } from "../../helpers.js";
 
 import {
   ComplexMarginMapping as HopperComplexMarginMapping,
@@ -9,51 +9,51 @@ import {
   SimpleMarginMapping as OrbiterSimpleMarginMapping,
 } from "@workleap/orbiter-ui";
 
-export const marginMapper = createStyleMapper({
+export const marginMapper = createCssPropertyMapper({
   propertyName: "margin",
   unsafePropertyName: "UNSAFE_margin",
-  orbiterValidKeys: OrbiterComplexMarginMapping,
-  hopperValidKeys: HopperComplexMarginMapping,
+  sourceValidKeys: OrbiterComplexMarginMapping,
+  targetValidKeys: HopperComplexMarginMapping,
 });
 
-export const marginBottomMapper = createStyleMapper({
+export const marginBottomMapper = createCssPropertyMapper({
   propertyName: "marginBottom",
   unsafePropertyName: "UNSAFE_marginBottom",
-  orbiterValidKeys: OrbiterSimpleMarginMapping,
-  hopperValidKeys: HopperSimpleMarginMapping,
+  sourceValidKeys: OrbiterSimpleMarginMapping,
+  targetValidKeys: HopperSimpleMarginMapping,
 });
 
-export const marginLeftMapper = createStyleMapper({
+export const marginLeftMapper = createCssPropertyMapper({
   propertyName: "marginLeft",
   unsafePropertyName: "UNSAFE_marginLeft",
-  orbiterValidKeys: OrbiterSimpleMarginMapping,
-  hopperValidKeys: HopperSimpleMarginMapping,
+  sourceValidKeys: OrbiterSimpleMarginMapping,
+  targetValidKeys: HopperSimpleMarginMapping,
 });
 
-export const marginRightMapper = createStyleMapper({
+export const marginRightMapper = createCssPropertyMapper({
   propertyName: "marginRight",
   unsafePropertyName: "UNSAFE_marginRight",
-  orbiterValidKeys: OrbiterSimpleMarginMapping,
-  hopperValidKeys: HopperSimpleMarginMapping,
+  sourceValidKeys: OrbiterSimpleMarginMapping,
+  targetValidKeys: HopperSimpleMarginMapping,
 });
 
-export const marginTopMapper = createStyleMapper({
+export const marginTopMapper = createCssPropertyMapper({
   propertyName: "marginTop",
   unsafePropertyName: "UNSAFE_marginTop",
-  orbiterValidKeys: OrbiterSimpleMarginMapping,
-  hopperValidKeys: HopperSimpleMarginMapping,
+  sourceValidKeys: OrbiterSimpleMarginMapping,
+  targetValidKeys: HopperSimpleMarginMapping,
 });
 
-export const marginXMapper = createStyleMapper({
+export const marginXMapper = createCssPropertyMapper({
   propertyName: "marginX",
   unsafePropertyName: "UNSAFE_marginX",
-  orbiterValidKeys: OrbiterSimpleMarginMapping,
-  hopperValidKeys: HopperSimpleMarginMapping,
+  sourceValidKeys: OrbiterSimpleMarginMapping,
+  targetValidKeys: HopperSimpleMarginMapping,
 });
 
-export const marginYMapper = createStyleMapper({
+export const marginYMapper = createCssPropertyMapper({
   propertyName: "marginY",
   unsafePropertyName: "UNSAFE_marginY",
-  orbiterValidKeys: OrbiterSimpleMarginMapping,
-  hopperValidKeys: HopperSimpleMarginMapping,
+  sourceValidKeys: OrbiterSimpleMarginMapping,
+  targetValidKeys: HopperSimpleMarginMapping,
 });

--- a/src/mappings/styled-system/styles/paddings.ts
+++ b/src/mappings/styled-system/styles/paddings.ts
@@ -1,4 +1,4 @@
-import { createStyleMapper } from "../../helpers.js";
+import { createCssPropertyMapper } from "../../helpers.js";
 import {
   HopperStyledSystemPropsKeys,
   StyledSystemPropertyMapper,
@@ -13,11 +13,11 @@ import {
   SimplePaddingMapping as OrbiterSimplePaddingMapping,
 } from "@workleap/orbiter-ui";
 
-export const paddingMapper = createStyleMapper({
+export const paddingMapper = createCssPropertyMapper({
   propertyName: "padding",
   unsafePropertyName: "UNSAFE_padding",
-  orbiterValidKeys: OrbiterComplexPaddingMapping,
-  hopperValidKeys: HopperComplexPaddingMapping,
+  sourceValidKeys: OrbiterComplexPaddingMapping,
+  targetValidKeys: HopperComplexPaddingMapping,
   customMapper: (value, originalValue, runtime) => {
     const { j } = runtime;
     if (typeof value === "number") {
@@ -30,44 +30,44 @@ export const paddingMapper = createStyleMapper({
   },
 });
 
-export const paddingBottomMapper = createStyleMapper({
+export const paddingBottomMapper = createCssPropertyMapper({
   propertyName: "paddingBottom",
   unsafePropertyName: "UNSAFE_paddingBottom",
-  orbiterValidKeys: OrbiterSimplePaddingMapping,
-  hopperValidKeys: HopperSimplePaddingMapping,
+  sourceValidKeys: OrbiterSimplePaddingMapping,
+  targetValidKeys: HopperSimplePaddingMapping,
 });
 
-export const paddingLeftMapper = createStyleMapper({
+export const paddingLeftMapper = createCssPropertyMapper({
   propertyName: "paddingLeft",
   unsafePropertyName: "UNSAFE_paddingLeft",
-  orbiterValidKeys: OrbiterSimplePaddingMapping,
-  hopperValidKeys: HopperSimplePaddingMapping,
+  sourceValidKeys: OrbiterSimplePaddingMapping,
+  targetValidKeys: HopperSimplePaddingMapping,
 });
 
-export const paddingRightMapper = createStyleMapper({
+export const paddingRightMapper = createCssPropertyMapper({
   propertyName: "paddingRight",
   unsafePropertyName: "UNSAFE_paddingRight",
-  orbiterValidKeys: OrbiterSimplePaddingMapping,
-  hopperValidKeys: HopperSimplePaddingMapping,
+  sourceValidKeys: OrbiterSimplePaddingMapping,
+  targetValidKeys: HopperSimplePaddingMapping,
 });
 
-export const paddingTopMapper = createStyleMapper({
+export const paddingTopMapper = createCssPropertyMapper({
   propertyName: "paddingTop",
   unsafePropertyName: "UNSAFE_paddingTop",
-  orbiterValidKeys: OrbiterSimplePaddingMapping,
-  hopperValidKeys: HopperSimplePaddingMapping,
+  sourceValidKeys: OrbiterSimplePaddingMapping,
+  targetValidKeys: HopperSimplePaddingMapping,
 });
 
-export const paddingXMapper = createStyleMapper({
+export const paddingXMapper = createCssPropertyMapper({
   propertyName: "paddingX",
   unsafePropertyName: "UNSAFE_paddingX",
-  orbiterValidKeys: OrbiterSimplePaddingMapping,
-  hopperValidKeys: HopperSimplePaddingMapping,
+  sourceValidKeys: OrbiterSimplePaddingMapping,
+  targetValidKeys: HopperSimplePaddingMapping,
 });
 
-export const paddingYMapper = createStyleMapper({
+export const paddingYMapper = createCssPropertyMapper({
   propertyName: "paddingY",
   unsafePropertyName: "UNSAFE_paddingY",
-  orbiterValidKeys: OrbiterSimplePaddingMapping,
-  hopperValidKeys: HopperSimplePaddingMapping,
+  sourceValidKeys: OrbiterSimplePaddingMapping,
+  targetValidKeys: HopperSimplePaddingMapping,
 });

--- a/src/mappings/styled-system/styles/sizings.ts
+++ b/src/mappings/styled-system/styles/sizings.ts
@@ -1,4 +1,4 @@
-import { createStyleMapper, isPercentageValue } from "../../helpers.js";
+import { createCssPropertyMapper, isPercentageValue } from "../../helpers.js";
 
 import {
   LineHeightMapping as HopperLineHeightMapping,
@@ -9,12 +9,12 @@ import {
   SizingMapping as OrbiterSizingMapping,
 } from "@workleap/orbiter-ui";
 
-export const widthMapper = createStyleMapper({
+export const widthMapper = createCssPropertyMapper({
   propertyName: "width",
   unsafePropertyName: "UNSAFE_width",
-  extraGlobalValues: ["auto", "fit-content", "max-content", "min-content"],
-  orbiterValidKeys: OrbiterSizingMapping,
-  hopperValidKeys: HopperSizingMapping,
+  validGlobalValues: ["auto", "fit-content", "max-content", "min-content"],
+  sourceValidKeys: OrbiterSizingMapping,
+  targetValidKeys: HopperSizingMapping,
   customMapper: (value, originalValue) => {
     if (isPercentageValue(value)) {
       return {
@@ -26,12 +26,12 @@ export const widthMapper = createStyleMapper({
   },
 });
 
-export const heightMapper = createStyleMapper({
+export const heightMapper = createCssPropertyMapper({
   propertyName: "height",
   unsafePropertyName: "UNSAFE_height",
-  extraGlobalValues: ["auto", "fit-content", "max-content", "min-content"],
-  orbiterValidKeys: OrbiterSizingMapping,
-  hopperValidKeys: HopperSizingMapping,
+  validGlobalValues: ["auto", "fit-content", "max-content", "min-content"],
+  sourceValidKeys: OrbiterSizingMapping,
+  targetValidKeys: HopperSizingMapping,
   customMapper: (value, originalValue) => {
     if (isPercentageValue(value)) {
       return {
@@ -43,12 +43,12 @@ export const heightMapper = createStyleMapper({
   },
 });
 
-export const minWidthMapper = createStyleMapper({
+export const minWidthMapper = createCssPropertyMapper({
   propertyName: "minWidth",
   unsafePropertyName: "UNSAFE_minWidth",
-  extraGlobalValues: ["auto", "fit-content", "max-content", "min-content"],
-  orbiterValidKeys: OrbiterSizingMapping,
-  hopperValidKeys: HopperSizingMapping,
+  validGlobalValues: ["auto", "fit-content", "max-content", "min-content"],
+  sourceValidKeys: OrbiterSizingMapping,
+  targetValidKeys: HopperSizingMapping,
   customMapper: (value, originalValue) => {
     if (isPercentageValue(value)) {
       return {
@@ -60,12 +60,12 @@ export const minWidthMapper = createStyleMapper({
   },
 });
 
-export const minHeightMapper = createStyleMapper({
+export const minHeightMapper = createCssPropertyMapper({
   propertyName: "minHeight",
   unsafePropertyName: "UNSAFE_minHeight",
-  extraGlobalValues: ["auto", "fit-content", "max-content", "min-content"],
-  orbiterValidKeys: OrbiterSizingMapping,
-  hopperValidKeys: HopperSizingMapping,
+  validGlobalValues: ["auto", "fit-content", "max-content", "min-content"],
+  sourceValidKeys: OrbiterSizingMapping,
+  targetValidKeys: HopperSizingMapping,
   customMapper: (value, originalValue) => {
     if (isPercentageValue(value)) {
       return {
@@ -77,12 +77,12 @@ export const minHeightMapper = createStyleMapper({
   },
 });
 
-export const maxWidthMapper = createStyleMapper({
+export const maxWidthMapper = createCssPropertyMapper({
   propertyName: "maxWidth",
   unsafePropertyName: "UNSAFE_maxWidth",
-  extraGlobalValues: ["auto", "fit-content", "max-content", "min-content"],
-  orbiterValidKeys: OrbiterSizingMapping,
-  hopperValidKeys: HopperSizingMapping,
+  validGlobalValues: ["auto", "fit-content", "max-content", "min-content"],
+  sourceValidKeys: OrbiterSizingMapping,
+  targetValidKeys: HopperSizingMapping,
   customMapper: (value, originalValue) => {
     if (isPercentageValue(value)) {
       return {
@@ -94,12 +94,12 @@ export const maxWidthMapper = createStyleMapper({
   },
 });
 
-export const maxHeightMapper = createStyleMapper({
+export const maxHeightMapper = createCssPropertyMapper({
   propertyName: "maxHeight",
   unsafePropertyName: "UNSAFE_maxHeight",
-  extraGlobalValues: ["auto", "fit-content", "max-content", "min-content"],
-  orbiterValidKeys: OrbiterSizingMapping,
-  hopperValidKeys: HopperSizingMapping,
+  validGlobalValues: ["auto", "fit-content", "max-content", "min-content"],
+  sourceValidKeys: OrbiterSizingMapping,
+  targetValidKeys: HopperSizingMapping,
   customMapper: (value, originalValue) => {
     if (isPercentageValue(value)) {
       return {
@@ -111,9 +111,9 @@ export const maxHeightMapper = createStyleMapper({
   },
 });
 
-export const lineHeightMapper = createStyleMapper({
+export const lineHeightMapper = createCssPropertyMapper({
   propertyName: "lineHeight",
   unsafePropertyName: "UNSAFE_lineHeight",
-  orbiterValidKeys: OrbiterLineHeightMapping,
-  hopperValidKeys: HopperLineHeightMapping,
+  sourceValidKeys: OrbiterLineHeightMapping,
+  targetValidKeys: HopperLineHeightMapping,
 });

--- a/test/test.ts
+++ b/test/test.ts
@@ -386,81 +386,93 @@ describe("component usage analysis", () => {
 
     // Check that the results are in the expected JSON format with usage counts
     assert.ok(
-      analysisResults.Div,
+      analysisResults.components.Div,
       "Div component should be present in results"
     );
     assert.ok(
-      analysisResults.Text,
+      analysisResults.components.Text,
       "Text component should be present in results"
     );
 
     // Check component usage count
     assert.strictEqual(
-      analysisResults.Div.usage,
+      analysisResults.components.Div.usage,
       1,
       "Div should have usage count of 1"
     );
     assert.strictEqual(
-      analysisResults.Text.usage,
+      analysisResults.components.Text.usage,
       1,
       "Text should have usage count of 1"
     );
 
     // Check prop counts
     assert.strictEqual(
-      Object.keys(analysisResults.Div.props).length,
+      Object.keys(analysisResults.components.Div.props).length,
       2,
       "Div should have 2 props"
     );
     assert.strictEqual(
-      analysisResults.Div.props.border?.usage,
+      analysisResults.components.Div.props.border?.usage,
       1,
       "Div border prop should have usage count of 1"
     );
     assert.ok(
-      analysisResults.Div.props.border?.values instanceof Set,
+      analysisResults.components.Div.props.border?.values instanceof Set,
       "Div border prop values should be a Set"
     );
     assert.strictEqual(
-      analysisResults.Div.props.width?.usage,
+      analysisResults.components.Div.props.width?.usage,
       1,
       "Div width prop should have usage count of 1"
     );
     assert.ok(
-      analysisResults.Div.props.width?.values instanceof Set,
+      analysisResults.components.Div.props.width?.values instanceof Set,
       "Div width prop values should be a Set"
     );
 
     // Check actual values stored in the Set
     assert.deepStrictEqual(
-      Array.from(analysisResults.Div.props.border?.values || []),
+      Array.from(analysisResults.components.Div.props.border?.values || []),
       ['"1px"'],
       "Div border values should contain '1px'"
     );
     assert.deepStrictEqual(
-      Array.from(analysisResults.Div.props.width?.values || []),
+      Array.from(analysisResults.components.Div.props.width?.values || []),
       ['"120px"'],
       "Div width values should contain '120px'"
     );
 
     assert.strictEqual(
-      Object.keys(analysisResults.Text.props).length,
+      Object.keys(analysisResults.components.Text.props).length,
       1,
       "Text should have 1 prop"
     );
     assert.strictEqual(
-      analysisResults.Text.props.fontSize?.usage,
+      analysisResults.components.Text.props.fontSize?.usage,
       1,
       "Text fontSize prop should have usage count of 1"
     );
     assert.ok(
-      analysisResults.Text.props.fontSize?.values instanceof Set,
+      analysisResults.components.Text.props.fontSize?.values instanceof Set,
       "Text fontSize prop values should be a Set"
     );
     assert.deepStrictEqual(
-      Array.from(analysisResults.Text.props.fontSize?.values || []),
+      Array.from(analysisResults.components.Text.props.fontSize?.values || []),
       ['"14px"'],
       "Text fontSize values should contain '14px'"
+    );
+
+    // Check overall statistics
+    assert.strictEqual(
+      analysisResults.overall.usage.components,
+      2,
+      "Overall component usage should be 2"
+    );
+    assert.strictEqual(
+      analysisResults.overall.usage.props,
+      3,
+      "Overall prop usage should be 3 (border + width + fontSize)"
     );
   });
 
@@ -471,39 +483,39 @@ describe("component usage analysis", () => {
 
     // Check expected component is present
     assert.ok(
-      analysisResults.Div,
+      analysisResults.components.Div,
       "Div component should be present in results"
     );
 
     // Check component usage count
     assert.strictEqual(
-      analysisResults.Div.usage,
+      analysisResults.components.Div.usage,
       1,
       "Div should have usage count of 1"
     );
 
     // Check prop counts
     assert.strictEqual(
-      Object.keys(analysisResults.Div.props).length,
+      Object.keys(analysisResults.components.Div.props).length,
       2,
       "Div should have 2 props"
     );
     assert.strictEqual(
-      analysisResults.Div.props.border?.usage,
+      analysisResults.components.Div.props.border?.usage,
       1,
       "Div border prop should have usage count of 1"
     );
     assert.ok(
-      analysisResults.Div.props.border?.values instanceof Set,
+      analysisResults.components.Div.props.border?.values instanceof Set,
       "Div border prop values should be a Set"
     );
     assert.strictEqual(
-      analysisResults.Div.props.width?.usage,
+      analysisResults.components.Div.props.width?.usage,
       1,
       "Div width prop should have usage count of 1"
     );
     assert.ok(
-      analysisResults.Div.props.width?.values instanceof Set,
+      analysisResults.components.Div.props.width?.values instanceof Set,
       "Div width prop values should be a Set"
     );
   });
@@ -515,39 +527,41 @@ describe("component usage analysis", () => {
 
     // Should include the unknown component and its props
     assert.ok(
-      analysisResults.UnknownComponent,
+      analysisResults.components.UnknownComponent,
       "UnknownComponent should be present in results"
     );
 
     // Check component usage count
     assert.strictEqual(
-      analysisResults.UnknownComponent.usage,
+      analysisResults.components.UnknownComponent.usage,
       1,
       "UnknownComponent should have usage count of 1"
     );
 
     // Check prop counts
     assert.strictEqual(
-      Object.keys(analysisResults.UnknownComponent.props).length,
+      Object.keys(analysisResults.components.UnknownComponent.props).length,
       2,
       "UnknownComponent should have 2 props"
     );
     assert.strictEqual(
-      analysisResults.UnknownComponent.props.prop1?.usage,
+      analysisResults.components.UnknownComponent.props.prop1?.usage,
       1,
       "UnknownComponent prop1 should have usage count of 1"
     );
     assert.ok(
-      analysisResults.UnknownComponent.props.prop1?.values instanceof Set,
+      analysisResults.components.UnknownComponent.props.prop1?.values instanceof
+        Set,
       "UnknownComponent prop1 values should be a Set"
     );
     assert.strictEqual(
-      analysisResults.UnknownComponent.props.prop2?.usage,
+      analysisResults.components.UnknownComponent.props.prop2?.usage,
       1,
       "UnknownComponent prop2 should have usage count of 1"
     );
     assert.ok(
-      analysisResults.UnknownComponent.props.prop2?.values instanceof Set,
+      analysisResults.components.UnknownComponent.props.prop2?.values instanceof
+        Set,
       "UnknownComponent prop2 values should be a Set"
     );
   });
@@ -573,57 +587,57 @@ describe("component usage analysis", () => {
     // Check component names
     const expectedComponents = ["Div", "Text"];
     assert.deepEqual(
-      Object.keys(analysisResults).sort(),
+      Object.keys(analysisResults.components).sort(),
       expectedComponents.sort()
     );
 
     // Check Div component
     assert.ok(
-      analysisResults.Div,
+      analysisResults.components.Div,
       "Div component should be present in results"
     );
     assert.strictEqual(
-      analysisResults.Div.usage,
+      analysisResults.components.Div.usage,
       2,
       "Div should have usage count of 2"
     );
 
     // Check Div props
-    const divProps = Object.keys(analysisResults.Div.props);
+    const divProps = Object.keys(analysisResults.components.Div.props);
     assert.strictEqual(divProps.length, 3, "Div should have 3 props");
     assert.ok(divProps.includes("width"), "Div should have width prop");
     assert.ok(divProps.includes("height"), "Div should have height prop");
     assert.ok(divProps.includes("maxWidth"), "Div should have maxWidth prop");
 
     assert.strictEqual(
-      analysisResults.Div.props.width?.usage,
+      analysisResults.components.Div.props.width?.usage,
       1,
       "width prop should have usage count of 1"
     );
     assert.strictEqual(
-      analysisResults.Div.props.height?.usage,
+      analysisResults.components.Div.props.height?.usage,
       2,
       "height prop should have usage count of 2"
     );
     assert.strictEqual(
-      analysisResults.Div.props.maxWidth?.usage,
+      analysisResults.components.Div.props.maxWidth?.usage,
       1,
       "maxWidth prop should have usage count of 1"
     );
 
     // Check Text component
     assert.ok(
-      analysisResults.Text,
+      analysisResults.components.Text,
       "Text component should be present in results"
     );
     assert.strictEqual(
-      analysisResults.Text.usage,
+      analysisResults.components.Text.usage,
       2,
       "Text should have usage count of 2"
     );
 
     // Check Text props
-    const textProps = Object.keys(analysisResults.Text.props);
+    const textProps = Object.keys(analysisResults.components.Text.props);
     assert.strictEqual(textProps.length, 2, "Text should have 2 props");
     assert.ok(textProps.includes("fontSize"), "Text should have fontSize prop");
     assert.ok(
@@ -632,12 +646,12 @@ describe("component usage analysis", () => {
     );
 
     assert.strictEqual(
-      analysisResults.Text.props.fontSize?.usage,
+      analysisResults.components.Text.props.fontSize?.usage,
       1,
       "fontSize prop should have usage count of 1"
     );
     assert.strictEqual(
-      analysisResults.Text.props.fontWeight?.usage,
+      analysisResults.components.Text.props.fontWeight?.usage,
       1,
       "fontWeight prop should have usage count of 1"
     );
@@ -656,30 +670,30 @@ describe("component usage analysis", () => {
     });
 
     assert.ok(
-      analysisResults.CustomComponent,
+      analysisResults.components.CustomComponent,
       "CustomComponent should be present in results"
     );
 
     // Check usage count
     assert.strictEqual(
-      analysisResults.CustomComponent.usage,
+      analysisResults.components.CustomComponent.usage,
       1,
       "CustomComponent should have usage count of 1"
     );
 
     // Check props
     assert.strictEqual(
-      Object.keys(analysisResults.CustomComponent.props).length,
+      Object.keys(analysisResults.components.CustomComponent.props).length,
       2,
       "CustomComponent should have 2 props"
     );
     assert.strictEqual(
-      analysisResults.CustomComponent.props.prop1?.usage,
+      analysisResults.components.CustomComponent.props.prop1?.usage,
       1,
       "prop1 should have usage count of 1"
     );
     assert.strictEqual(
-      analysisResults.CustomComponent.props.prop2?.usage,
+      analysisResults.components.CustomComponent.props.prop2?.usage,
       1,
       "prop2 should have usage count of 1"
     );
@@ -704,56 +718,56 @@ describe("component usage analysis", () => {
 
     // Should only include components used with JSX, not hooks or utility functions
     assert.deepEqual(
-      Object.keys(analysisResults).sort(),
+      Object.keys(analysisResults.components).sort(),
       ["Button", "Text"].sort(),
       "Only actual components should be included in results"
     );
 
     // Check Button component
     assert.ok(
-      analysisResults.Button,
+      analysisResults.components.Button,
       "Button component should be present in results"
     );
     assert.strictEqual(
-      analysisResults.Button.usage,
+      analysisResults.components.Button.usage,
       1,
       "Button should have usage count of 1"
     );
     assert.strictEqual(
-      Object.keys(analysisResults.Button.props).length,
+      Object.keys(analysisResults.components.Button.props).length,
       2,
       "Button should have 2 props"
     );
     assert.strictEqual(
-      analysisResults.Button.props.onClick?.usage,
+      analysisResults.components.Button.props.onClick?.usage,
       1,
       "onClick prop should have usage count of 1"
     );
     assert.strictEqual(
-      analysisResults.Button.props.size?.usage,
+      analysisResults.components.Button.props.size?.usage,
       1,
       "size prop should have usage count of 1"
     );
 
     // Check Text component
     assert.ok(
-      analysisResults.Text,
+      analysisResults.components.Text,
       "Text component should be present in results"
     );
     assert.strictEqual(
-      analysisResults.Text.usage,
+      analysisResults.components.Text.usage,
       1,
       "Text should have usage count of 1"
     );
 
     // Verify hooks and utility functions are not included
     assert.strictEqual(
-      analysisResults.useHook,
+      analysisResults.components.useHook,
       undefined,
       "Hook should not be present in results"
     );
     assert.strictEqual(
-      analysisResults.utilFunction,
+      analysisResults.components.utilFunction,
       undefined,
       "Utility function should not be present in results"
     );
@@ -777,32 +791,32 @@ describe("component usage analysis", () => {
     const { analysisResults } = analyze(getRuntime(INPUT), null);
 
     // Check that the Div component exists with correct usage count
-    assert.ok(analysisResults.Div, "Div component should exist");
+    assert.ok(analysisResults.components.Div, "Div component should exist");
     assert.strictEqual(
-      analysisResults.Div.usage,
+      analysisResults.components.Div.usage,
       3,
       "Div should have 3 usages"
     );
 
     // Check that properties have correct counts
     assert.strictEqual(
-      analysisResults.Div.props.width?.usage,
+      analysisResults.components.Div.props.width?.usage,
       3,
       "width prop should be used 3 times"
     );
     assert.strictEqual(
-      analysisResults.Div.props.padding?.usage,
+      analysisResults.components.Div.props.padding?.usage,
       2,
       "padding prop should be used 2 times"
     );
     assert.strictEqual(
-      analysisResults.Div.props.height?.usage,
+      analysisResults.components.Div.props.height?.usage,
       1,
       "height prop should be used 1 time"
     );
 
     // Get properties sorted by usage count
-    const propEntries = Object.entries(analysisResults.Div.props);
+    const propEntries = Object.entries(analysisResults.components.Div.props);
     const sortedProps = propEntries
       .sort(([, a], [, b]) => b.usage - a.usage)
       .map(([name]) => name);
@@ -856,18 +870,21 @@ describe("component usage analysis", () => {
     const { analysisResults } = analyze(getRuntime(INPUT), null);
 
     // Check Button prop values
-    assert.ok(analysisResults.Button, "Button should be present in results");
+    assert.ok(
+      analysisResults.components.Button,
+      "Button should be present in results"
+    );
 
     // String literal value
     assert.deepStrictEqual(
-      Array.from(analysisResults.Button.props.variant?.values || []),
+      Array.from(analysisResults.components.Button.props.variant?.values || []),
       ['"primary"'],
       "Button variant values should contain 'primary'"
     );
 
     // Function expression (partial match since it might include whitespace differences)
     const onClickValues = Array.from(
-      analysisResults.Button.props.onClick?.values || []
+      analysisResults.components.Button.props.onClick?.values || []
     );
     assert.ok(
       onClickValues.some((value) => value.includes("console.log")),
@@ -876,7 +893,7 @@ describe("component usage analysis", () => {
 
     // Boolean expression
     const disabledValues = Array.from(
-      analysisResults.Button.props.disabled?.values || []
+      analysisResults.components.Button.props.disabled?.values || []
     );
     assert.ok(
       disabledValues.some((value) => value.includes("true")),
@@ -885,14 +902,16 @@ describe("component usage analysis", () => {
 
     // String literal with hyphen
     assert.deepStrictEqual(
-      Array.from(analysisResults.Button.props["data-testid"]?.values || []),
+      Array.from(
+        analysisResults.components.Button.props["data-testid"]?.values || []
+      ),
       ['"test-button"'],
       "data-testid should contain 'test-button'"
     );
 
     // Template literal
     const ariaLabelValues = Array.from(
-      analysisResults.Button.props["aria-label"]?.values || []
+      analysisResults.components.Button.props["aria-label"]?.values || []
     );
     assert.ok(
       ariaLabelValues.some((value) => value.includes("dynamicValue")),
@@ -900,18 +919,21 @@ describe("component usage analysis", () => {
     );
 
     // Check Div prop values
-    assert.ok(analysisResults.Div, "Div should be present in results");
+    assert.ok(
+      analysisResults.components.Div,
+      "Div should be present in results"
+    );
 
     // String literal (width)
     assert.deepStrictEqual(
-      Array.from(analysisResults.Div.props.width?.values || []),
+      Array.from(analysisResults.components.Div.props.width?.values || []),
       ['"100px"'],
       "Div width values should contain '100px'"
     );
 
     // Numeric literal
     const heightValues = Array.from(
-      analysisResults.Div.props.height?.values || []
+      analysisResults.components.Div.props.height?.values || []
     );
     assert.ok(
       heightValues.some((value) => value.includes("200")),
@@ -920,7 +942,7 @@ describe("component usage analysis", () => {
 
     // Object expression
     const marginValues = Array.from(
-      analysisResults.Div.props.margin?.values || []
+      analysisResults.components.Div.props.margin?.values || []
     );
     assert.ok(
       marginValues.some(
@@ -931,7 +953,7 @@ describe("component usage analysis", () => {
 
     // Array expression
     const paddingValues = Array.from(
-      analysisResults.Div.props.padding?.values || []
+      analysisResults.components.Div.props.padding?.values || []
     );
     assert.ok(
       paddingValues.some((value) => value.includes("[") && value.includes("]")),
@@ -939,9 +961,12 @@ describe("component usage analysis", () => {
     );
 
     // Variable reference
-    assert.ok(analysisResults.Text, "Text should be present in results");
+    assert.ok(
+      analysisResults.components.Text,
+      "Text should be present in results"
+    );
     const fontSizeValues = Array.from(
-      analysisResults.Text?.props.fontSize?.values || []
+      analysisResults.components.Text?.props.fontSize?.values || []
     );
     assert.ok(
       fontSizeValues.some((value) => value.includes("dynamicValue")),
@@ -966,24 +991,27 @@ describe("component usage analysis", () => {
     const { analysisResults } = analyze(getRuntime(INPUT), null);
 
     // Check button component exists
-    assert.ok(analysisResults.Button, "Button should be present in results");
+    assert.ok(
+      analysisResults.components.Button,
+      "Button should be present in results"
+    );
 
     // Check usage count
     assert.strictEqual(
-      analysisResults.Button.usage,
+      analysisResults.components.Button.usage,
       3,
       "Button should have 3 usages"
     );
 
     // Check variant values
     assert.strictEqual(
-      analysisResults.Button.props.variant?.usage,
+      analysisResults.components.Button.props.variant?.usage,
       3,
       "variant prop should have usage count of 3"
     );
 
     const variantValues = Array.from(
-      analysisResults.Button.props.variant?.values || []
+      analysisResults.components.Button.props.variant?.values || []
     ).sort();
     assert.deepStrictEqual(
       variantValues,
@@ -993,13 +1021,13 @@ describe("component usage analysis", () => {
 
     // Check size values
     assert.strictEqual(
-      analysisResults.Button.props.size?.usage,
+      analysisResults.components.Button.props.size?.usage,
       3,
       "size prop should have usage count of 3"
     );
 
     const sizeValues = Array.from(
-      analysisResults.Button.props.size?.values || []
+      analysisResults.components.Button.props.size?.values || []
     ).sort();
     assert.deepStrictEqual(
       sizeValues,
@@ -1012,66 +1040,110 @@ describe("component usage analysis", () => {
 describe("analyze file aggregation", () => {
   test("mergeAnalysisResults combines component usage and prop counts correctly", () => {
     const existingResults = {
-      Button: {
-        usage: 5,
-        props: {
-          variant: { usage: 3, values: new Set(["primary", "secondary"]) },
-          size: { usage: 5, values: new Set(["lg", "sm"]) },
-          disabled: { usage: 2, values: new Set(["true"]) },
+      overall: {
+        usage: {
+          components: 13, // 5 + 8
+          props: 20, // 3 + 5 + 2 + 6 + 4
         },
       },
-      Text: {
-        usage: 8,
-        props: {
-          fontSize: { usage: 6, values: new Set(["14px", "16px"]) },
-          color: { usage: 4, values: new Set(["red", "blue"]) },
+      components: {
+        Button: {
+          usage: 5,
+          props: {
+            variant: { usage: 3, values: new Set(["primary", "secondary"]) },
+            size: { usage: 5, values: new Set(["lg", "sm"]) },
+            disabled: { usage: 2, values: new Set(["true"]) },
+          },
+        },
+        Text: {
+          usage: 8,
+          props: {
+            fontSize: { usage: 6, values: new Set(["14px", "16px"]) },
+            color: { usage: 4, values: new Set(["red", "blue"]) },
+          },
         },
       },
     };
 
     const newResults = {
-      Button: {
-        usage: 3,
-        props: {
-          variant: { usage: 2, values: new Set(["primary", "tertiary"]) },
-          onClick: { usage: 3, values: new Set(["() => {}"]) },
-          "aria-label": { usage: 1, values: new Set(["Button label"]) },
+      overall: {
+        usage: {
+          components: 7, // 3 + 4
+          props: 9, // 2 + 3 + 1 + 3
         },
       },
-      Div: {
-        usage: 4,
-        props: {
-          width: { usage: 3, values: new Set(["100px", "auto"]) },
-          padding: { usage: 2, values: new Set(["10px"]) },
+      components: {
+        Button: {
+          usage: 3,
+          props: {
+            variant: { usage: 2, values: new Set(["primary", "tertiary"]) },
+            onClick: { usage: 3, values: new Set(["() => {}"]) },
+            "aria-label": { usage: 1, values: new Set(["Button label"]) },
+          },
+        },
+        Div: {
+          usage: 4,
+          props: {
+            width: { usage: 3, values: new Set(["100px", "auto"]) },
+            padding: { usage: 2, values: new Set(["10px"]) },
+          },
         },
       },
     };
 
     const mergedResults = mergeAnalysisResults(existingResults, newResults);
 
+    // Verify overall statistics are correctly calculated
+    assert.strictEqual(
+      mergedResults.overall.usage.components,
+      20, // 5+3 + 8 + 4
+      "Overall component usage should be correctly summed"
+    );
+    assert.strictEqual(
+      mergedResults.overall.usage.props,
+      31, // Button: 5+5+2+3+1=16, Text: 6+4=10, Div: 3+2=5, Total: 31
+      "Overall prop usage should be correctly summed"
+    );
+
     // Verify components exist in merged results
-    assert.ok(mergedResults.Button, "Button should exist in merged results");
-    assert.ok(mergedResults.Text, "Text should exist in merged results");
-    assert.ok(mergedResults.Div, "Div should exist in merged results");
+    assert.ok(
+      mergedResults.components.Button,
+      "Button should exist in merged results"
+    );
+    assert.ok(
+      mergedResults.components.Text,
+      "Text should exist in merged results"
+    );
+    assert.ok(
+      mergedResults.components.Div,
+      "Div should exist in merged results"
+    );
 
     // Check that component usage counts are summed
     assert.strictEqual(
-      mergedResults.Button.usage,
+      mergedResults.components.Button.usage,
       8,
       "Button usage should be summed to 8"
     );
     assert.strictEqual(
-      mergedResults.Text.usage,
+      mergedResults.components.Text.usage,
       8,
       "Text usage should remain 8"
     );
-    assert.strictEqual(mergedResults.Div.usage, 4, "Div usage should be 4");
+    assert.strictEqual(
+      mergedResults.components.Div.usage,
+      4,
+      "Div usage should be 4"
+    );
 
     // Check Button props are merged correctly
-    assert.ok(mergedResults.Button?.props, "Button should have props");
+    assert.ok(
+      mergedResults.components.Button?.props,
+      "Button should have props"
+    );
 
     // Use type assertions to handle TypeScript's possibly undefined warnings
-    const buttonProps = mergedResults.Button!.props;
+    const buttonProps = mergedResults.components.Button!.props;
 
     assert.strictEqual(
       buttonProps.variant!.usage,
@@ -1106,10 +1178,10 @@ describe("analyze file aggregation", () => {
     );
 
     // Check Text props remain unchanged
-    assert.ok(mergedResults.Text?.props, "Text should have props");
+    assert.ok(mergedResults.components.Text?.props, "Text should have props");
 
     // Use type assertions for Text props
-    const textProps = mergedResults.Text!.props;
+    const textProps = mergedResults.components.Text!.props;
 
     assert.strictEqual(
       textProps.fontSize!.usage,
@@ -1123,10 +1195,10 @@ describe("analyze file aggregation", () => {
     );
 
     // Check Div is added correctly
-    assert.ok(mergedResults.Div?.props, "Div should have props");
+    assert.ok(mergedResults.components.Div?.props, "Div should have props");
 
     // Use type assertions for Div props
-    const divProps = mergedResults.Div!.props;
+    const divProps = mergedResults.components.Div!.props;
 
     assert.strictEqual(
       divProps.width!.usage,
@@ -1162,39 +1234,39 @@ describe("analyze file aggregation", () => {
 
     // Check Button props have correct counts
     assert.strictEqual(
-      analysisResults["Button"]!.props.variant?.usage,
+      analysisResults.components["Button"]!.props.variant?.usage,
       3,
       "Button variant prop should have 3 usages"
     );
     assert.strictEqual(
-      analysisResults["Button"]!.props.size?.usage,
+      analysisResults.components["Button"]!.props.size?.usage,
       3,
       "Button size prop should have 3 usages"
     );
 
     // Check Text props have correct counts
     assert.strictEqual(
-      analysisResults["Text"]!.props.fontSize?.usage,
+      analysisResults.components["Text"]!.props.fontSize?.usage,
       2,
       "Text fontSize prop should have 2 usages"
     );
 
     // Check Div props have correct counts
     assert.strictEqual(
-      analysisResults["Div"]!.props.width?.usage,
+      analysisResults.components["Div"]!.props.width?.usage,
       1,
       "Div width prop should have 1 usage"
     );
     assert.strictEqual(
-      analysisResults["Div"]!.props.height?.usage,
+      analysisResults.components["Div"]!.props.height?.usage,
       1,
       "Div height prop should have 1 usage"
     );
 
     // Verify Button props are properly ordered by usage
-    const buttonProps = Object.entries(analysisResults["Button"]!.props).map(
-      ([name]) => name
-    );
+    const buttonProps = Object.entries(
+      analysisResults.components["Button"]!.props
+    ).map(([name]) => name);
 
     // Both variant and size are used 3 times, so they should both be included early in the list
     assert.ok(
@@ -1207,9 +1279,9 @@ describe("analyze file aggregation", () => {
     );
 
     // Verify Text props are properly ordered
-    const textProps = Object.entries(analysisResults["Text"]!.props).map(
-      ([name]) => name
-    );
+    const textProps = Object.entries(
+      analysisResults.components["Text"]!.props
+    ).map(([name]) => name);
 
     // fontSize is used 2 times, so it should be first
     assert.strictEqual(
@@ -1240,30 +1312,30 @@ describe("analyze file aggregation", () => {
 
     // Check prop counts with mixed usage
     assert.strictEqual(
-      mixedResults["Button"]!.props.variant?.usage,
+      mixedResults.components["Button"]!.props.variant?.usage,
       3,
       "variant should be used 3 times"
     );
     assert.strictEqual(
-      mixedResults["Button"]!.props.size?.usage,
+      mixedResults.components["Button"]!.props.size?.usage,
       3,
       "size should be used 3 times"
     );
     assert.strictEqual(
-      mixedResults["Button"]!.props.onClick?.usage,
+      mixedResults.components["Button"]!.props.onClick?.usage,
       2,
       "onClick should be used 2 times"
     );
     assert.strictEqual(
-      mixedResults["Button"]!.props.disabled?.usage,
+      mixedResults.components["Button"]!.props.disabled?.usage,
       1,
       "disabled should be used 1 time"
     );
 
     // Get Button props sorted by usage
-    const mixedButtonProps = Object.entries(mixedResults["Button"]!.props).map(
-      ([name]) => name
-    );
+    const mixedButtonProps = Object.entries(
+      mixedResults.components["Button"]!.props
+    ).map(([name]) => name);
 
     // Props should be sorted by usage count (variant/size > onClick > disabled)
     assert.ok(
@@ -1308,31 +1380,38 @@ describe("analyze file aggregation", () => {
     const { analysisResults } = analyze(getRuntime(INPUT), null);
 
     // Expected order by usage count: Text (5), Div (4), Button (2), Box (1)
-    const componentNames = Object.keys(analysisResults);
+    const componentNames = Object.keys(analysisResults.components);
 
     // First, verify we have all expected components
-    assert.ok(analysisResults.Div, "Div component should exist");
-    assert.ok(analysisResults.Text, "Text component should exist");
-    assert.ok(analysisResults.Button, "Button component should exist");
-    assert.ok(analysisResults.Box, "Box component should exist");
+    assert.ok(analysisResults.components.Div, "Div component should exist");
+    assert.ok(analysisResults.components.Text, "Text component should exist");
+    assert.ok(
+      analysisResults.components.Button,
+      "Button component should exist"
+    );
+    assert.ok(analysisResults.components.Box, "Box component should exist");
 
     // Verify component usage counts
     assert.strictEqual(
-      analysisResults.Div.usage,
+      analysisResults.components.Div.usage,
       4,
       "Div should have 4 usages"
     );
     assert.strictEqual(
-      analysisResults.Text.usage,
+      analysisResults.components.Text.usage,
       5,
       "Text should have 5 usages"
     );
     assert.strictEqual(
-      analysisResults.Button.usage,
+      analysisResults.components.Button.usage,
       2,
       "Button should have 2 usages"
     );
-    assert.strictEqual(analysisResults.Box.usage, 1, "Box should have 1 usage");
+    assert.strictEqual(
+      analysisResults.components.Box.usage,
+      1,
+      "Box should have 1 usage"
+    );
 
     // Check the order of components
     assert.strictEqual(
@@ -1364,7 +1443,7 @@ describe("analyze file aggregation", () => {
 
     // Verify that Alert is not included (not used in JSX)
     assert.strictEqual(
-      analysisResults.Alert,
+      analysisResults.components.Alert,
       undefined,
       "Alert should not be included"
     );
@@ -1375,12 +1454,20 @@ describe("JSON serialization", () => {
   test("correctly serializes and deserializes Set objects", () => {
     // Create a sample analysis result with Set objects
     const testResults: AnalysisResults = {
-      Button: {
-        usage: 5,
-        props: {
-          variant: {
-            usage: 3,
-            values: new Set(["primary", "secondary"]),
+      overall: {
+        usage: {
+          components: 5,
+          props: 3,
+        },
+      },
+      components: {
+        Button: {
+          usage: 5,
+          props: {
+            variant: {
+              usage: 3,
+              values: new Set(["primary", "secondary"]),
+            },
           },
         },
       },
@@ -1400,31 +1487,43 @@ describe("JSON serialization", () => {
 
     // Verify the Button component exists
     assert.ok(
-      parsedResults.Button,
+      parsedResults.components.Button,
       "Button component should exist in parsed results"
     );
 
     // Verify structure is preserved
     assert.strictEqual(
-      parsedResults.Button!.usage,
+      parsedResults.components.Button!.usage,
       5,
       "Component usage count should be preserved"
     );
 
+    // Verify overall statistics are preserved
+    assert.strictEqual(
+      parsedResults.overall.usage.components,
+      5,
+      "Overall component usage should be preserved"
+    );
+    assert.strictEqual(
+      parsedResults.overall.usage.props,
+      3,
+      "Overall prop usage should be preserved"
+    );
+
     // Verify the variant prop exists
     assert.ok(
-      parsedResults.Button!.props.variant,
+      parsedResults.components.Button!.props.variant,
       "Button variant prop should exist"
     );
 
     // Most importantly, verify the Set was correctly restored
     assert.ok(
-      parsedResults.Button!.props.variant!.values instanceof Set,
+      parsedResults.components.Button!.props.variant!.values instanceof Set,
       "Values should be restored as a Set"
     );
 
     const restoredValues = Array.from(
-      parsedResults.Button!.props.variant!.values
+      parsedResults.components.Button!.props.variant!.values
     );
     assert.strictEqual(restoredValues.length, 2, "Set should have 2 values");
     assert.ok(


### PR DESCRIPTION
…rall statistics

- Change AnalysisResults from flat component mapping to nested structure
- Add overall.usage.components and overall.usage.props for aggregated statistics
- Move component data under 'components' property
- Update analyze() function to calculate overall statistics
- Enhance mergeAnalysisResults() to properly combine overall stats
- Update all tests to use new nested structure
- Increment version to 0.18.0
- Add copilot PR instructions