### PR TITLE
feat: add --include-ignorelist option to analysis

### DIFF
--- a/.codemodrc.json
+++ b/.codemodrc.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://codemod-utils.s3.us-west-1.amazonaws.com/configuration_schema.json",
   "name": "workleap/orbiter-to-hopper",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "engine": "jscodeshift",
   "private": false,
   "arguments": [

--- a/README.md
+++ b/README.md
@@ -100,6 +100,20 @@ npx codemod workleap/orbiter-to-hopper -a orbiter-usage-not-mapped-components.js
 npx codemod workleap/orbiter-to-hopper -a orbiter-usage-not-mapped-props.json --filter-unmapped props -n 1
 ```
 
+**Include ignored properties in analysis:**
+
+By default, the analysis excludes standard React/DOM properties like `aria-*`, `data-*`, `className`, `style`, etc. to focus on component-specific migration needs. To include these properties in the analysis, use the `--include-ignoreList` flag:
+
+```bash
+npx codemod workleap/orbiter-to-hopper -a orbiter-usage-complete.json --include-ignoreList -n 1
+```
+
+This can be combined with other filters for comprehensive analysis:
+
+```bash
+npx codemod workleap/orbiter-to-hopper -a orbiter-usage-all-unmapped.json --filter-unmapped props --include-ignoreList -n 1
+```
+
 This command generates a JSON file (`orbiter-usage.json`) containing usage statistics ordered by frequency. The output format prioritizes frequently used components and their properties:
 
 ```json
@@ -313,6 +327,7 @@ The comments will be added as inline comments next to the transformed property, 
 **Function parameters:**
 
 Property mapping functions receive two parameters:
+
 1. `originalValue`: The original attribute value from the JSX element
 2. Context object containing:
    - `j`: The jscodeshift API for creating new AST nodes

--- a/reports/orbiter-not-mapped-props.json
+++ b/reports/orbiter-not-mapped-props.json
@@ -1,22 +1,22 @@
 {
   "overall": {
     "usage": {
-      "components": 1249,
-      "props": 1170
+      "components": 1177,
+      "props": 1080
     }
   },
   "components": {
     "Text": {
-      "usage": 582,
+      "usage": 577,
       "props": {
         "size": {
           "usage": 466,
           "values": [
-            "\"md\"",
             "\"sm\"",
-            "\"xs\"",
-            "\"2xl\"",
             "\"lg\"",
+            "\"xs\"",
+            "\"md\"",
+            "\"2xl\"",
             "fontSize",
             "{ base: \"lg\", xs: \"2xl\" }",
             "\"inherit\"",
@@ -34,42 +34,11 @@
             "fileName"
           ]
         },
-        "id": {
-          "usage": 6,
-          "values": [
-            "\"label-everyoneInMyIntegrationAccount\"",
-            "\"label-everyoneInTheFollowingIntegrationGroups\""
-          ]
-        },
-        "role": {
-          "usage": 4,
-          "values": [
-            "\"status\"",
-            "\"cell\"",
-            "\"columnheader\""
-          ]
-        },
         "as": {
           "usage": 2,
           "values": [
             "\"div\""
           ]
-        },
-        "aria-live": {
-          "usage": 2,
-          "values": [
-            "durationInMs ? \"assertive\" : \"polite\""
-          ]
-        },
-        "aria-hidden": {
-          "usage": 1,
-          "values": [
-            "\"true\""
-          ]
-        },
-        "aria-readonly": {
-          "usage": 1,
-          "values": []
         },
         "dangerouslySetInnerHTML": {
           "usage": 1,
@@ -80,7 +49,7 @@
       }
     },
     "Heading": {
-      "usage": 297,
+      "usage": 296,
       "props": {
         "size": {
           "usage": 268,
@@ -94,35 +63,20 @@
             "{ base: \"lg\", sm: \"xl\" }",
             "{ base: \"md\", md: \"lg\" }",
             "headingSize",
-            "{ base: \"sm\", sm: \"lg\" }",
             "{ base: \"lg\", xs: \"xl\" }",
             "{ base: \"lg\", xs: \"3xl\" }",
             "{ base: \"lg\", sm:\"2xl\" }",
             "{ base: \"sm\", sm: \"xl\" }",
+            "{ base: \"sm\", sm: \"lg\" }",
             "{ base: \"lg\", xs: \"2xl\" }",
             "\"3xl\"",
             "{ base: \"md\", sm: \"2xl\" }"
-          ]
-        },
-        "id": {
-          "usage": 6,
-          "values": [
-            "`${popupId}-title`",
-            "\"themeLabel\"",
-            "\"st-billing-information-heading\"",
-            "\"planSelectionPage_featureComparisonTable\""
           ]
         },
         "as": {
           "usage": 1,
           "values": [
             "as"
-          ]
-        },
-        "data-wl-test-id": {
-          "usage": 1,
-          "values": [
-            "\"home-page-title\""
           ]
         },
         "onMouseEnter": {
@@ -140,36 +94,12 @@
       }
     },
     "Div": {
-      "usage": 97,
+      "usage": 69,
       "props": {
         "min-width": {
           "usage": 21,
           "values": [
             "\"100dvh\""
-          ]
-        },
-        "role": {
-          "usage": 16,
-          "values": [
-            "\"button\"",
-            "\"presentation\"",
-            "\"table\"",
-            "\"rowgroup\"",
-            "\"columnheader\""
-          ]
-        },
-        "id": {
-          "usage": 13,
-          "values": [
-            "reviewCycle.reviewCycleId",
-            "\"assign-user-product\"",
-            "\"column-logo-name-status\"",
-            "\"section-max-name-status\"",
-            "\"column-tenants-button\"",
-            "\"sticky-placeholder\"",
-            "\"assign-user-roles\"",
-            "\"wai-conversation-view-anchor\"",
-            "`hubspot-form-${hubspotFormId}`"
           ]
         },
         "onClick": {
@@ -239,18 +169,23 @@
         }
       }
     },
-    "Flex": {
-      "usage": 75,
+    "Paragraph": {
+      "usage": 57,
       "props": {
-        "role": {
-          "usage": 13,
+        "size": {
+          "usage": 54,
           "values": [
-            "\"button\"",
-            "\"columnheader\"",
-            "\"cell\"",
-            "\"row\""
+            "\"sm\"",
+            "\"xs\"",
+            "\"lg\"",
+            "\"md\""
           ]
-        },
+        }
+      }
+    },
+    "Flex": {
+      "usage": 52,
+      "props": {
         "shrink": {
           "usage": 7,
           "values": [
@@ -262,18 +197,9 @@
         "onClick": {
           "usage": 5,
           "values": [
-            "handleOnClick",
             "handleFocusInput",
+            "handleOnClick",
             "expandInfo"
-          ]
-        },
-        "id": {
-          "usage": 4,
-          "values": [
-            "\"sb-page\"",
-            "id",
-            "\"cell-inside-row\"",
-            "\"section-name-status\""
           ]
         },
         "onDragEnter": {
@@ -321,13 +247,6 @@
             "() => onBlur?.()"
           ]
         },
-        "data-index": {
-          "usage": 2,
-          "values": [
-            "virtualRow.index",
-            "index"
-          ]
-        },
         "inline": {
           "usage": 1,
           "values": []
@@ -344,18 +263,6 @@
             "e => {\n    if (e.key === \"Enter\" || e.key === \" \") {\n        expandInfo();\n    }\n}"
           ]
         },
-        "onMouseEnter": {
-          "usage": 1,
-          "values": [
-            "() => handleMouseEnter(integration)"
-          ]
-        },
-        "onMouseLeave": {
-          "usage": 1,
-          "values": [
-            "handleMouseLeave"
-          ]
-        },
         "padding-left": {
           "usage": 1,
           "values": [
@@ -368,22 +275,16 @@
             "\"inset-md\""
           ]
         },
-        "reverse": {
+        "onMouseEnter": {
           "usage": 1,
-          "values": []
-        }
-      }
-    },
-    "Paragraph": {
-      "usage": 57,
-      "props": {
-        "size": {
-          "usage": 54,
           "values": [
-            "\"sm\"",
-            "\"xs\"",
-            "\"lg\"",
-            "\"md\""
+            "() => handleMouseEnter(integration)"
+          ]
+        },
+        "onMouseLeave": {
+          "usage": 1,
+          "values": [
+            "handleMouseLeave"
           ]
         }
       }
@@ -433,8 +334,8 @@
         "size": {
           "usage": 16,
           "values": [
-            "\"xs\"",
             "\"sm\"",
+            "\"xs\"",
             "\"lg\""
           ]
         }
@@ -446,8 +347,8 @@
         "size": {
           "usage": 12,
           "values": [
-            "\"3xl\"",
             "\"xl\"",
+            "\"3xl\"",
             "\"2xl\"",
             "\"xs\"",
             "\"md\"",
@@ -519,30 +420,6 @@
         }
       }
     },
-    "Span": {
-      "usage": 8,
-      "props": {
-        "id": {
-          "usage": 3,
-          "values": [
-            "\"st-pay-cta\"",
-            "organizationAuthenticationUrlControlId"
-          ]
-        },
-        "role": {
-          "usage": 1,
-          "values": [
-            "\"img\""
-          ]
-        },
-        "aria-hidden": {
-          "usage": 1,
-          "values": [
-            "label != null"
-          ]
-        }
-      }
-    },
     "Content": {
       "usage": 6,
       "props": {
@@ -588,23 +465,16 @@
         "type": {
           "usage": 6,
           "values": [
-            "\"file\"",
-            "\"text\""
+            "\"text\"",
+            "\"file\""
           ]
         },
         "onChange": {
           "usage": 6,
           "values": [
-            "handleFileChange",
             "handleChange",
+            "handleFileChange",
             "onChange"
-          ]
-        },
-        "id": {
-          "usage": 4,
-          "values": [
-            "\"file\"",
-            "field.id"
           ]
         },
         "onKeyDown": {
@@ -680,12 +550,6 @@
             "handleBlur"
           ]
         },
-        "data-wl-test-id": {
-          "usage": 1,
-          "values": [
-            "\"emailListInput\""
-          ]
-        },
         "multiple": {
           "usage": 1,
           "values": []
@@ -693,14 +557,8 @@
       }
     },
     "Grid": {
-      "usage": 5,
+      "usage": 3,
       "props": {
-        "role": {
-          "usage": 2,
-          "values": [
-            "\"row\""
-          ]
-        },
         "onTransitionStart": {
           "usage": 2,
           "values": [
@@ -715,19 +573,8 @@
         }
       }
     },
-    "Main": {
-      "usage": 3,
-      "props": {
-        "id": {
-          "usage": 3,
-          "values": [
-            "\"main-content\""
-          ]
-        }
-      }
-    },
     "UL": {
-      "usage": 3,
+      "usage": 2,
       "props": {
         "onMouseEnter": {
           "usage": 1,
@@ -746,12 +593,6 @@
           "values": [
             "e => fetchMoreOnBottomReached(e.currentTarget)"
           ]
-        },
-        "id": {
-          "usage": 1,
-          "values": [
-            "authorizedSlackWorkspacesControlId"
-          ]
         }
       }
     },
@@ -763,12 +604,6 @@
           "values": [
             "cellPadding",
             "8"
-          ]
-        },
-        "role": {
-          "usage": 1,
-          "values": [
-            "\"grid\""
           ]
         }
       }
@@ -792,12 +627,6 @@
           "values": [
             "scope"
           ]
-        },
-        "aria-sort": {
-          "usage": 1,
-          "values": [
-            "ariaSort"
-          ]
         }
       }
     },
@@ -808,23 +637,6 @@
           "usage": 1,
           "values": [
             "columnCount"
-          ]
-        },
-        "aria-colspan": {
-          "usage": 1,
-          "values": [
-            "columnCount"
-          ]
-        }
-      }
-    },
-    "TR": {
-      "usage": 1,
-      "props": {
-        "aria-rowindex": {
-          "usage": 1,
-          "values": [
-            "HEADER_ROWS_COUNT + rowCount + 1"
           ]
         }
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,9 @@ export default function transform(
           | "components"
           | "props"
           | undefined,
+        "include-ignoreList": options["include-ignoreList"] as
+          | boolean
+          | undefined,
       });
       return result.source;
     } else {

--- a/src/mappings/index.ts
+++ b/src/mappings/index.ts
@@ -1,33 +1,21 @@
-import { MapMetaData } from "../utils/types.ts";
+import {
+  ComponentMapMetaData,
+  MapMetaData,
+  PropsMapping,
+} from "../utils/types.ts";
 import { layoutComponentsMappings } from "./layout-components-mappings.ts";
 import { styledSystemPropsMappings } from "./styled-system/mappings.ts";
 
-//it is a list of known props that are ignored in the migration
-//but we keep them in the mappings so we can ignore reporting them as missing
-const knownIgnoredProps = {
-  "data-testid": "data-testid",
-  "aria-label": "aria-label",
-  "aria-labelledby": "aria-labelledby",
-  "aria-describedby": "aria-describedby",
-  "aria-disabled": "aria-disabled",
-  "aria-busy": "aria-busy",
-  "data-public": "data-public",
-  "data-private": "data-private",
-  className: "className",
-  style: "style",
-  key: "key",
-  ref: "ref",
-  slot: "slot",
-  id: "id",
-  role: "role",
-};
-
 const defaultPropsMappings = {
-  ...knownIgnoredProps,
   ...styledSystemPropsMappings,
   disabled: "isDisabled",
   readOnly: "isReadOnly",
-};
+  "min-width": (originalValue) => ({
+    to: "min-width",
+    value: originalValue,
+    comments: `TODO: It seems it is an invalid property. Remove it if not needed`,
+  }),
+} satisfies PropsMapping;
 
 export const mappings = {
   sourcePackage: "@workleap/orbiter-ui",

--- a/src/mappings/layout-components-mappings.ts
+++ b/src/mappings/layout-components-mappings.ts
@@ -54,6 +54,7 @@ export const layoutComponentsMappings = {
   HtmlInputProps: "HtmlInputProps",
   HtmlSection: "HtmlSection",
   HtmlSectionProps: "HtmlSectionProps",
+  HtmlForm: "HtmlForm",
 
   //basic wrappers over html elements
   A: "A",

--- a/src/migrations/migrateComponent.ts
+++ b/src/migrations/migrateComponent.ts
@@ -51,6 +51,7 @@ export function migrateComponent(
 
     Object.entries(propsMetadata?.mappings || {}).forEach(
       ([oldAttrName, newAttrName]) => {
+        if (oldAttrName === newAttrName) return; // Skip if no change
         migrateAttribute(instances, oldAttrName, newAttrName, runtime);
       }
     );

--- a/test/input.tsx
+++ b/test/input.tsx
@@ -19,6 +19,7 @@ import {
   Heading,
   HtmlButton,
   HtmlFooter,
+  HtmlForm,
   HtmlH1,
   HtmlH1Props,
   HtmlH2,
@@ -382,6 +383,11 @@ export function App() {
       <HtmlHeader padding={400}>text</HtmlHeader>
       <Img border="rock-400" src="Planet" />
       <HtmlInput type="email">text</HtmlInput>
+      <HtmlForm
+        aria-label="test"
+        data-testId="test"
+        min-width="100vdh"
+      ></HtmlForm>
       <Nav flexWrap={"revert-layer"}>
         <UL color="neutral-weak" marginLeft={"revert"}>
           <LI color="sapphire-600">Colonize</LI>

--- a/test/output.txt
+++ b/test/output.txt
@@ -36,6 +36,7 @@ import {
   HtmlH6,
   HtmlInput,
   HtmlSection,
+  HtmlForm,
   A,
   Address,
   Article,
@@ -400,6 +401,11 @@ export function App() {
       <HtmlHeader padding="core_400">text</HtmlHeader>
       <Img border="core_rock-400" src="Planet" />
       <HtmlInput type="email">text</HtmlInput>
+      <HtmlForm
+        aria-label="test"
+        data-testId="test"
+        min-width="100vdh"/*TODO: It seems it is an invalid property. Remove it if not needed*/
+      ></HtmlForm>
       <Nav flexWrap={"revert-layer"}>
         <UL color="neutral-weak" marginLeft={"revert"}>
           <LI color="core_sapphire-600">Colonize</LI>


### PR DESCRIPTION
This PR adds a new --include-ignorelist option to the analysis functionality that allows users to control whether standard React/DOM properties should be included in the analysis output.

## Changes

### Core Functionality
- Property filtering: By default, analysis now excludes aria-* attributes, data-* attributes, and known ignored props
- New CLI option: Added --include-ignorelist flag to include all properties when needed
- Function signature update: Modified analyze() function to accept the new option parameter

### Implementation Details
- Added shouldIgnoreProperty() function that checks if a property should be filtered out
- Updated property collection logic with proper precedence order to handle ignore list vs unmapped filtering
- Enhanced CLI integration to pass through the new option

### Testing
- Added 7 comprehensive test cases covering all filtering scenarios
- Tests verify default exclusion behavior, include behavior with flag, and interaction with existing --filter-unmapped options
- All existing tests continue to pass

### Documentation
- Updated README with clear examples of the new option usage
- Added section explaining default filtering behavior and how to override it

## Benefits
- Focused analysis: By default, excludes standard React/DOM props to focus on component-specific migration needs
- Flexibility: Allows comprehensive analysis when needed via the flag
- Backward compatibility: Existing workflows continue to work with improved default behavior
- Better UX: Reduces noise in analysis output while maintaining full capability when required