### PR TITLE
Add Tag and Lozenge component mappings with new categories

### DIFF
--- a/.codemodrc.json
+++ b/.codemodrc.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://codemod-utils.s3.us-west-1.amazonaws.com/configuration_schema.json",
   "name": "workleap/orbiter-to-hopper",
-  "version": "0.45.0",
+  "version": "0.46.0",
   "engine": "jscodeshift",
   "private": false,
   "arguments": [

--- a/README.md
+++ b/README.md
@@ -17,9 +17,7 @@ The codemod handles various migration scenarios including:
 - [Usage Guide](#usage-guide)
   - [Running Migrations](#running-migrations)
     - [Migrate All Components](#migrate-all-components)
-    - [Migrate Layout Components Only](#migrate-layout-components-only)
-    - [Migrate Button Components Only](#migrate-button-components-only)
-    - [Migrate Visual Components Only](#migrate-visual-components-only)
+    - [Migrate Component Categories](#migrate-component-categories)
     - [Migrate Specific Components](#migrate-specific-components)
     - [Target a Specific Path](#target-a-specific-path)
     - [Additional Options](#additional-options)
@@ -64,29 +62,16 @@ export function App() {
 pnpx codemod workleap/orbiter-to-hopper
 ```
 
-#### Migrate Layout Components Only
+#### Migrate Component Categories
 
-Migrate layout and structural components only (Flex, Grid, Div, Span, Article, Nav, ...). This includes all layout containers, HTML wrapper components, content elements, and placeholders. You can see the complete list in [layout-components-mappings.ts](/src/mappings/orbiter/layout-components-mappings.ts) file.
-
-```bash
-pnpx codemod workleap/orbiter-to-hopper -c layout
-```
-
-#### Migrate Button Components Only
-
-Migrate buttons components only. You can see the complete list in [button-components-mappings.ts](/src/mappings/orbiter/button-components-mappings.ts) file.
-
-```bash
-pnpx codemod workleap/orbiter-to-hopper -c buttons
-```
-
-#### Migrate Visual Components Only
-
-Migrate visual components only (Avatar, AvatarText, Badge, Image, Illustration, Spinner, ...). This includes visual elements that often represent data or provide feedback. You can see the complete list in [visual-components-mappings.ts](/src/mappings/orbiter/visual-components-mappings.ts) file.
-
-```bash
-pnpx codemod workleap/orbiter-to-hopper -c visual
-```
+| Category | Description | Command | Mapping File |
+|----------|-------------|---------|--------------|
+| **Layout** | Layout containers, HTML wrappers, content elements (Flex, Grid, Div, Span, Article, Nav, ...) | `pnpx codemod workleap/orbiter-to-hopper -c layout` | [layout-components-mappings.ts](/src/mappings/orbiter/layout-components-mappings.ts) |
+| **Buttons** | Button components and variants | `pnpx codemod workleap/orbiter-to-hopper -c buttons` | [button-components-mappings.ts](/src/mappings/orbiter/button-components-mappings.ts) |
+| **Visual** | Visual elements and feedback components (Avatar, Image, Illustration, Spinner, ...) | `pnpx codemod workleap/orbiter-to-hopper -c visual` | [visual-components-mappings.ts](/src/mappings/orbiter/visual-components-mappings.ts) |
+| **Menu** | Menu and navigation components (Menu, MenuItem, ListBox, ListBoxItem, ...) | `pnpx codemod workleap/orbiter-to-hopper -c menu` | [menu-components-mappings.ts](/src/mappings/orbiter/menu-components-mappings.ts) |
+| **Overlay** | Overlay and dialog components (Modal, Popover, Tooltip, ...) | `pnpx codemod workleap/orbiter-to-hopper -c overlay` | [overlay-components-mappings.ts](/src/mappings/orbiter/overlay-components-mappings.ts) |
+| **Tags** | Tag and labeling components (Tag, TagGroup, Lozenge, ...) | `pnpx codemod workleap/orbiter-to-hopper -c tags` | [tags-components-mappings.ts](/src/mappings/orbiter/tags-components-mappings.ts) |
 
 #### Migrate Specific Components
 
@@ -279,7 +264,7 @@ This command generates a JSON file (`orbiter-usage.json`) containing usage stati
 
 ## Shimmed components
 
-Shimmed components are compatibility layers that bridge the gap between Orbiter and Hopper component implementations. 
+Shimmed components are compatibility layers that bridge the gap between Orbiter and Hopper component implementations.
 They're designed to ease the migration process by preserving the expected behavior and API of Orbiter components while using Hopper's underlying implementation.
 
 When a component's implementation differs significantly between the two design systems, a shim can provide a transitional solution that:
@@ -289,7 +274,7 @@ When a component's implementation differs significantly between the two design s
 - Handles prop transformations that can't be handled by simple one-to-one mappings
 - Reduces the need for extensive manual refactoring
 
-Shims are particularly useful for complex components where the mental model or component architecture has changed between design systems. 
+Shims are particularly useful for complex components where the mental model or component architecture has changed between design systems.
 They allow you to migrate your codebase incrementally while maintaining functionality.
 
 ### Card
@@ -307,4 +292,3 @@ See the [Stackblitz](https://stackblitz.com/edit/hopper-sandbox-qs8euohl?file=sr
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed guidelines on how to contribute to this project.
-****

--- a/src/mappings/orbiter/button-components-mappings.ts
+++ b/src/mappings/orbiter/button-components-mappings.ts
@@ -32,5 +32,4 @@ export const buttonComponentsMappings: Record<string, ComponentMapping> = {
   ...textLinkAsButtonMapping,
   ...iconLinkMapping,
   ...iconLinkAsButtonMapping
-
 };

--- a/src/mappings/orbiter/components/lozenge.ts
+++ b/src/mappings/orbiter/components/lozenge.ts
@@ -1,0 +1,53 @@
+import { tryGettingLiteralValue } from "../../../utils/mapping.ts";
+import type { ComponentMapping } from "../../../utils/types.ts";
+
+export const lozengeMapping = {
+  Lozenge: {
+    to: "Tag",
+    props: {
+      mappings: {    
+        highlight: (originalValue, runtime) => {
+          const { j } = runtime;
+          const value = tryGettingLiteralValue(originalValue, runtime);
+          if (!originalValue || Boolean(value) != false) {
+            return {
+              to: "textTransform",
+              value: j.stringLiteral("uppercase")
+            };
+          }
+
+          return {
+            todoComments: "`highlight` is not supported anymore. Use textTransform=uppercase instead. More details: https://hopper.workleap.design/components/Tag"
+          };
+        },
+       
+        variant: (originalValue, runtime) => {
+          const value = tryGettingLiteralValue(originalValue, runtime);
+          const map: Record<string, string> = {
+            "negative": "negative",
+            "positive": "positive",
+            "warning": "caution",
+            "informative": "progress"
+          } ;
+
+          if (typeof value === "string" && map[value]) {
+            return {
+              value: runtime.j.stringLiteral(map[value])
+            };
+          } else {
+            return {
+              todoComments: "Map `negative`->`Negative`, `warning`->`Caution`, `informative`->`Progress`, and `positive`->`Positive` manually if needed. More details: https://workleap.atlassian.net/wiki/spaces/TL/pages/5529272372/Orbiter+to+Hopper+Migration"
+            };
+          }
+        },
+        
+        size: () => ({
+          migrationNotes: "The alternative `Tag` might be a bit taller(4px) than the old `Lozenge` even with the same size. Make sure you validate the design after the migration."
+        })
+
+      }
+       
+    }
+  },
+  LozengeProps: "TagProps"
+} satisfies Record<string, ComponentMapping>;

--- a/src/mappings/orbiter/components/tag.ts
+++ b/src/mappings/orbiter/components/tag.ts
@@ -1,0 +1,93 @@
+import { tryGettingLiteralValue } from "../../../utils/mapping.ts";
+import type { ComponentMapping } from "../../../utils/types.ts";
+
+export const tagMapping = {
+  Tag: {
+    props: {
+      mappings: {    
+        fluid: (originalValue, runtime) => {
+          const { j } = runtime;
+          const value = tryGettingLiteralValue(originalValue, runtime);
+          if (!originalValue || Boolean(value) != false) {
+            return {
+              to: "width",
+              value: j.stringLiteral("100%")
+            };
+          }
+
+          return {
+            todoComments: "`fluid` is not supported anymore. You can use width=100% instead. More details: https://hopper.workleap.design/components/Tag#migration-notes"
+          };
+        },
+
+        onClick: () => ({
+          todoComments: "`onClick` is not supported anymore. Alternative solution is to wrap it inside a `TagGroup` and use `onSelectionChange` callback. More details: https://hopper.workleap.design/components/Tag#migration-notes"
+        }),
+
+        onRemove: () => ({
+          todoComments: "`onRemove` is not supported anymore. Alternative solution is to wrap it inside a `TagGroup` and use its `onRemove` callback. More details: https://hopper.workleap.design/components/TagGroup#usage-removable"
+        }),
+
+        title: () => ({
+          todoComments: "`title` is not supported anymore. Wrap it inside a `Tooltip` component instead. More details: https://hopper.workleap.design/components/Tag#migration-notes"
+        }),
+
+        onKeyDown: () => ({
+          todoComments: "`onKeyDown` is not supported anymore. Alternative solution is to wrap it inside a `TagGroup` and use `onSelectionChange` callback. More details: https://hopper.workleap.design/components/Tag#migration-notes"
+        }),
+
+        tabIndex: () => ({
+          todoComments: "`tabIndex` is not supported anymore. Check if it is relevant, but probably it is safe to remove. More details: https://hopper.workleap.design/components/Tag#migration-notes"
+        }),
+
+        validationState: (originalValue, runtime) => {
+          const { j } = runtime;
+          const value = tryGettingLiteralValue(originalValue, runtime);
+          if (value === "invalid") {
+            return {
+              to: "isInvalid",
+              value: j.jsxExpressionContainer(j.booleanLiteral(true))
+            };
+          } else if (value === "valid") {
+            return {            
+              to: "isInvalid",
+              value: j.jsxExpressionContainer(j.booleanLiteral(false))
+            };
+          } else {
+            return {             
+              todoComments: "The `validationState` prop is not supported anymore. Use `isInvalid` prop instead. More details: https://hopper.workleap.design/components/Tag#migration-notes"
+            };
+          }
+        },
+
+        variant: (originalValue, runtime) => {
+          const value = tryGettingLiteralValue(originalValue, runtime);
+          if (value === "solid") {
+            return {
+              to: "variant",
+              value: runtime.j.stringLiteral("subdued")
+            };
+          } else if (value === "outline") {
+            return {
+              to: "variant",
+              value: runtime.j.stringLiteral("neutral")
+            };
+          } else {
+            return {
+              todoComments: "Map `solid`->`subdued` and `outline`->`neutral` manually if needed. More details: https://hopper.workleap.design/components/Tag#migration-notes"
+            };
+          }
+        }
+      },
+      additions: {
+        variant: "subdued"
+      }     
+    }
+  },
+  TagProps: "TagProps"
+} satisfies Record<string, ComponentMapping>;
+
+export const tagListMapping = {
+  TagList: "TagGroup",
+  TagListProps: "TagGroupProps"
+} satisfies Record<string, ComponentMapping>;  

--- a/src/mappings/orbiter/components/tileLink.ts
+++ b/src/mappings/orbiter/components/tileLink.ts
@@ -3,8 +3,15 @@ import type { ComponentMapping } from "../../../utils/types.ts";
 export const tileLinkMapping = {
   TileLink: {
     skipImport: true,
-    todoComments:
-      "`TileLink` is not supported yet. You can follow this to implement one: https://dev.azure.com/sharegate/ShareGate.One/_git/ShareGate.One?path=/src/frontend/client/src/components/TileLink/TileLink.tsx&version=GBmain&_a=contents "
+    todoComments:  "`TileLink` is not supported anymore. Check the generated migration notes for more details.",    
+    migrationNotes:
+      "`TileLink` is not supported. You should manually implement a `Link` with a `Tile` inside. You can also follow this to implement one: https://dev.azure.com/sharegate/ShareGate.One/_git/ShareGate.One?path=/src/frontend/client/src/components/TileLink/TileLink.tsx&version=GBmain&_a=contents "
   },
-  TileLinkProps: "TileLinkProps"
+  TileLinkProps: {
+    skipImport: true,
+    todoComments:  "`TileLinkProps` is not supported anymore. Check the generated migration notes for more details.",    
+    migrationNotes:
+      // eslint-disable-next-line max-len
+      "`TileLinkProps` is not supported. You should manually implement a `Link` with a `Tile` inside. You can also follow this to implement one: https://dev.azure.com/sharegate/ShareGate.One/_git/ShareGate.One?path=/src/frontend/client/src/components/TileLink/TileLink.tsx&version=GBmain&_a=contents "
+  }
 } satisfies Record<string, ComponentMapping>;

--- a/src/mappings/orbiter/index.ts
+++ b/src/mappings/orbiter/index.ts
@@ -10,6 +10,7 @@ import { layoutComponentsMappings } from "./layout-components-mappings.ts";
 import { menuComponentsMappings } from "./menu-components-mappings.ts";
 import { overlayComponentsMappings } from "./overlay-components-mappings.ts";
 import { styledSystemPropsMappings } from "./styled-system/mappings.ts";
+import { tagComponentsMappings } from "./tags-components-mappings.ts";
 import { visualComponentsMappings } from "./visual-components-mappings.ts";
 
 const defaultPropsMappings = {
@@ -41,7 +42,10 @@ export const mappings = {
   categories: {
     layout: getMappingKeys(layoutComponentsMappings),
     buttons: getMappingKeys(buttonComponentsMappings),
-    visual: getMappingKeys(visualComponentsMappings)
+    visual: getMappingKeys(visualComponentsMappings),
+    menu: getMappingKeys(menuComponentsMappings),
+    overlay: getMappingKeys(overlayComponentsMappings),
+    tags: getMappingKeys(tagComponentsMappings)
   },
   components: {
     ...layoutComponentsMappings,
@@ -50,7 +54,8 @@ export const mappings = {
     ...overlayComponentsMappings,
     ...menuComponentsMappings,
     ...itemMapping,
-    ...sectionMapping
+    ...sectionMapping,
+    ...tagComponentsMappings
   }
 } satisfies MapMetaData;
 
@@ -97,14 +102,6 @@ const todo = {
   AlertTrigger: "AlertTrigger", //usage: 10
   AlertTriggerProps: "AlertTriggerProps",
 
-  //tags & tiles - total usage: 74
-  Tag: "Tag", //usage: 64
-  TagProps: "TagProps",
-  TagList: "TagGroup", //usage: 6
-  TagListProps: "TagGroupProps",
-  // TODO: Not a direct mapping. Find the appropriate component/type.
-  // TileLink: "TileLink", //usage: 4
-  // TileLinkProps: "TileLinkProps",
 
   //toolbar & utilities - total usage: 33
   ThemeProvider: "HopperProvider", //usage: 30
@@ -112,8 +109,6 @@ const todo = {
   // TODO: Not a direct mapping. Find the appropriate component/type.
   // Toolbar: "Toolbar",
   // ToolbarProps: "ToolbarProps",
-  // VisuallyHidden: "VisuallyHidden", //usage: 1
-  // VisuallyHiddenProps: "VisuallyHiddenProps",
   // Transition: "Transition", //usage: 2
   // TransitionProps: "TransitionProps",
 

--- a/src/mappings/orbiter/layout-components-mappings.ts
+++ b/src/mappings/orbiter/layout-components-mappings.ts
@@ -1,3 +1,4 @@
+import { Divider } from "@hopper-ui/components";
 import type { ComponentMapping } from "../../utils/types.ts";
 import { flexMapping } from "./components/flex.ts";
 import { gridMappings } from "./components/grid.ts";
@@ -80,5 +81,8 @@ export const layoutComponentsMappings = {
   Nav: "Nav",
   NavProps: "NavProps",
   Span: "Span",
-  SpanProps: "SpanProps"
+  SpanProps: "SpanProps",
+
+  Divider: "Divider",
+  DividerProps: "DividerProps"
 } satisfies Record<string, ComponentMapping>;

--- a/src/mappings/orbiter/tags-components-mappings.ts
+++ b/src/mappings/orbiter/tags-components-mappings.ts
@@ -1,0 +1,10 @@
+import type { ComponentMapping } from "../../utils/types.ts";
+import { lozengeMapping } from "./components/lozenge.ts";
+import { tagListMapping, tagMapping } from "./components/tag.ts";
+
+
+export const tagComponentsMappings: Record<string, ComponentMapping> = {
+  ...tagMapping,
+  ...tagListMapping,
+  ...lozengeMapping
+};

--- a/src/mappings/orbiter/test/mocks/input.tsx
+++ b/src/mappings/orbiter/test/mocks/input.tsx
@@ -20,6 +20,7 @@ import {
   CrossButton,
   DeletedAvatar,
   Div,
+  Divider,
   Dot,
   Flex,
   Footer,
@@ -59,6 +60,7 @@ import {
   Link,
   Listbox,
   Item as ListboxItem,
+  Lozenge,
   Main,
   Menu,
   MenuTrigger,
@@ -76,6 +78,8 @@ import {
   Stack,
   SvgImage,
   Table,
+  Tag,
+  TagList,
   TBody,
   TD,
   Text,
@@ -94,6 +98,7 @@ import {
   TR,
   UL,
   useAccordionContext,
+  VisuallyHidden,
   type ContentProps,
 } from "@workleap/orbiter-ui";
 
@@ -885,7 +890,58 @@ export function App() {
         </Section>
         <Item>Item 3</Item>
       </Menu>
-      
+
+      {/* Divider */}
+      <Divider orientation="horizontal" />
+      <Divider orientation="vertical" />
+
+      {/* Tag */}
+      <Tag
+        fluid
+        validationState="invalid"
+        variant="outline"
+        size="md"
+        title="Tag Title"
+        onClick={() => {}}
+        onRemove={() => {}}
+        onKeyDown={() => {}}
+        tabIndex={0}
+      >
+        text
+      </Tag>
+      <Tag variant="solid">text</Tag>
+      <Tag>text</Tag>
+      <Tag variant={variable ? "outline": "solid"}>text</Tag>
+      <Tag fluid={false}>text</Tag>
+      <Tag validationState={"valid"}>text</Tag>
+      <Tag validationState={variable ? "invalid": "valid"}>
+        text
+      </Tag>
+      <TagList
+        readOnly
+        onRemove={() => {}}
+      >
+        text
+      </TagList>
+
+      {/* Lozenge */}
+      <Lozenge
+        highlight
+        size="md"
+      >
+        text
+      </Lozenge>
+      <Lozenge highlight={true}>text</Lozenge>
+      <Lozenge highlight={false}>text</Lozenge>
+      <Lozenge variant="negative">text</Lozenge>
+      <Lozenge variant="informative">text</Lozenge>
+      <Lozenge variant="warning">text</Lozenge>
+      <Lozenge variant="positive">text</Lozenge>
+      <Lozenge variant={variable ? "informative" : "negative"}>text</Lozenge>
+      <Lozenge size="sm">text</Lozenge>
+
+      {/* VisuallyHidden */}
+      <VisuallyHidden />
       {/* ------------------------------------------------------------------------------------------ */}
       <HopperDiv padding={"core_400"}>text</HopperDiv>
       <HopperLB>

--- a/src/mappings/orbiter/test/mocks/migration-notes-expected.md
+++ b/src/mappings/orbiter/test/mocks/migration-notes-expected.md
@@ -7,5 +7,11 @@
 - **Dot**: `Dot` is not supported anymore. Find an alternative. One possible option: `<Badge isIndeterminate />`
   - test.tsx
 
+- **Lozenge.size**: The alternative `Tag` might be a bit taller(4px) than the old `Lozenge` even with the same size. Make sure you validate the design after the migration.
+  - test.tsx
+
 - **Overlay**: `Overlay` is not supported anymore. Remove it and move its props to `Modal` instead and use `isOpen` prop instead of `show`.
+  - test.tsx
+
+- **TileLink**: `TileLink` is not supported. You should manually implement a `Link` with a `Tile` inside. You can also follow this to implement one: https://dev.azure.com/sharegate/ShareGate.One/_git/ShareGate.One?path=/src/frontend/client/src/components/TileLink/TileLink.tsx&version=GBmain&_a=contents 
   - test.tsx

--- a/src/mappings/orbiter/test/mocks/output.tsx
+++ b/src/mappings/orbiter/test/mocks/output.tsx
@@ -14,6 +14,7 @@ import {
   type ContentProps,
   DeletedAvatar,
   Div,
+  Divider,
   Flex,
   Footer,
   Grid,
@@ -69,6 +70,8 @@ import {
   Stack,
   SvgImage,
   Table,
+  Tag,
+  TagGroup,
   TBody,
   TD,
   Text,
@@ -82,6 +85,7 @@ import {
   TooltipTrigger,
   TR,
   UL,
+  VisuallyHidden,
 } from "@hopper-ui/components";
 import { SparklesIcon } from "@hopper-ui/icons";
 import { Alert, Counter, Dot, Overlay, TileLink, useAccordionContext } from "@workleap/orbiter-ui";
@@ -534,7 +538,7 @@ export function App() {
       >
         text
       </Tile>
-      /* Migration TODO: `TileLink` is not supported yet. You can follow this to implement one: https://dev.azure.com/sharegate/ShareGate.One/_git/ShareGate.One?path=/src/frontend/client/src/components/TileLink/TileLink.tsx&version=GBmain&_a=contents  */
+      /* Migration TODO: `TileLink` is not supported anymore. Check the generated migration notes for more details. */
       <TileLink
         href="https://example.com"
         external
@@ -892,6 +896,58 @@ export function App() {
         </MenuSection>
         <MenuItem>Item 3</MenuItem>
       </Menu>
+      {/* Divider */}
+      <Divider orientation="horizontal" />
+      <Divider orientation="vertical" />
+      {/* Tag */}
+      <Tag
+        width="100%"
+        isInvalid={true}
+        variant="neutral"
+        size="md"
+        title="Tag Title"/* Migration TODO: `title` is not supported anymore. Wrap it inside a `Tooltip` component instead. More details: https://hopper.workleap.design/components/Tag#migration-notes */
+        onClick={() => {}}/* Migration TODO: `onClick` is not supported anymore. Alternative solution is to wrap it inside a `TagGroup` and use `onSelectionChange` callback. More details: https://hopper.workleap.design/components/Tag#migration-notes */
+        onRemove={() => {}}/* Migration TODO: `onRemove` is not supported anymore. Alternative solution is to wrap it inside a `TagGroup` and use its `onRemove` callback. More details: https://hopper.workleap.design/components/TagGroup#usage-removable */
+        onKeyDown={() => {}}/* Migration TODO: `onKeyDown` is not supported anymore. Alternative solution is to wrap it inside a `TagGroup` and use `onSelectionChange` callback. More details: https://hopper.workleap.design/components/Tag#migration-notes */
+        tabIndex={0}/* Migration TODO: `tabIndex` is not supported anymore. Check if it is relevant, but probably it is safe to remove. More details: https://hopper.workleap.design/components/Tag#migration-notes */
+      >
+        text
+      </Tag>
+      <Tag variant="subdued">text</Tag>
+      <Tag variant="subdued">text</Tag>
+      <Tag variant={variable ? "outline": "solid"}/* Migration TODO: Map `solid`->`subdued` and `outline`->`neutral` manually if needed. More details: https://hopper.workleap.design/components/Tag#migration-notes */>text</Tag>
+      <Tag
+        fluid={false}/* Migration TODO: `fluid` is not supported anymore. You can use width=100% instead. More details: https://hopper.workleap.design/components/Tag#migration-notes */
+        variant="subdued">text</Tag>
+      <Tag isInvalid={false} variant="subdued">text</Tag>
+      <Tag
+        validationState={variable ? "invalid": "valid"}/* Migration TODO: The `validationState` prop is not supported anymore. Use `isInvalid` prop instead. More details: https://hopper.workleap.design/components/Tag#migration-notes */
+        variant="subdued">
+        text
+      </Tag>
+      <TagGroup
+        isReadOnly
+        onRemove={() => {}}
+      >
+        text
+      </TagGroup>
+      {/* Lozenge */}
+      <Tag
+        textTransform="uppercase"
+        size="md"
+      >
+        text
+      </Tag>
+      <Tag textTransform="uppercase">text</Tag>
+      <Tag highlight={false}/* Migration TODO: `highlight` is not supported anymore. Use textTransform=uppercase instead. More details: https://hopper.workleap.design/components/Tag */>text</Tag>
+      <Tag variant="negative">text</Tag>
+      <Tag variant="progress">text</Tag>
+      <Tag variant="caution">text</Tag>
+      <Tag variant="positive">text</Tag>
+      <Tag variant={variable ? "informative" : "negative"}/* Migration TODO: Map `negative`->`Negative`, `warning`->`Caution`, `informative`->`Progress`, and `positive`->`Positive` manually if needed. More details: https://workleap.atlassian.net/wiki/spaces/TL/pages/5529272372/Orbiter+to+Hopper+Migration */>text</Tag>
+      <Tag size="sm">text</Tag>
+      {/* VisuallyHidden */}
+      <VisuallyHidden />
       {/* ------------------------------------------------------------------------------------------ */}
       <HopperDiv padding={"core_400"}>text</HopperDiv>
       <HopperLB>

--- a/src/mappings/orbiter/visual-components-mappings.ts
+++ b/src/mappings/orbiter/visual-components-mappings.ts
@@ -31,12 +31,11 @@ export const visualComponentsMappings: Record<string, ComponentMapping> = {
     migrationNotes: "`Counter` is not supported anymore. You need to find an alternative. You can see this as an example:https://dev.azure.com/sharegate/ShareGate.Protect.Web/_git/ShareGate.Protect.Web/commit/8c969df4da52b1a0208d54e295762f36aa364ce4?path=/apps/tenant-assessment/src/pages/sharing-links.%5BworkspaceId%5D.tsx&version=GBmain&line=83&lineEnd=89&lineStartColumn=1&lineEndColumn=1&type=2&lineStyle=plain&_a=files"
   },
 
+  VisuallyHidden: "VisuallyHidden", //usage: 1
+  VisuallyHiddenProps: "VisuallyHiddenProps",
+
   ...spinnerMapping,
   ...avatarTextMapping,
   ...imageMapping,
   ...illustrationMapping
-
-  // Lozenge: "Badge", //usage: 90
-  // LozengeProps: "BadgeProps",
-
 };

--- a/src/utils/migration.ts
+++ b/src/utils/migration.ts
@@ -83,19 +83,30 @@ export function resolveComponentMapping(
     return null;
   }
 
-  const mappingItems = Array.isArray(componentMapping) ? componentMapping : [componentMapping];
+  if (!Array.isArray(componentMapping)) {
+    return componentMapping;
+  }
 
-  for (const mappingItem of mappingItems) {
-    if (typeof mappingItem === "function") {
-      if (!tag) {continue;} // Skip if tag is undefined. It only happens when we are using types, like DivProps. Function mapping will not be applied in this case.
+  if (tag) { // When we are using types, like DivProps, function mapping will not be applied in this case.
+    for (const mappingItem of componentMapping) {
       const result = mappingItem(tag, runtime);
       if (result) {
         return result;
       }
-    } else {
-      return mappingItem;
     }
   }
 
   return null;
+}
+
+export function tryToGetStaticMapping(
+  componentName: string,
+  runtime: Runtime
+): ComponentMapMetaData | undefined {
+  const { mappings } = runtime;
+  const componentMapping = mappings.components[componentName];
+
+  if (componentMapping && !Array.isArray(componentMapping)) {
+    return componentMapping;
+  }
 }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -85,6 +85,9 @@ export interface MapMetaData {
     layout: string[];
     buttons: string[];
     visual: string[];
+    menu: string[];
+    overlay: string[];
+    tags: string[];
   };
   components: Record<string, ComponentMapping>;
 }


### PR DESCRIPTION
## Summary

Added comprehensive mappings for Tag and Lozenge components along with new component categories to improve migration organization.

## Changes

### New Components
- **Tag**: Complete mapping with prop transformations, validation states, and migration notes
- **Lozenge**: Maps to Hopper Tag component with `textTransform='uppercase'`

### New Categories
- **menu**: Menu and navigation components (Menu, MenuItem, ListBox, etc.)
- **overlay**: Overlay components (Modal, Popover, Tooltip, etc.) 
- **tags**: Tag and labeling components (Tag, TagGroup, Lozenge, etc.)

### Documentation
- Updated README.md with new component categories in simplified table format
- Added comprehensive migration guidance and examples

### Technical
- Extended TypeScript types to support new categories
- Incremented version to 0.46.0
- Added migration notes for complex prop mappings

## Testing
- All existing tests pass
- New mappings follow established patterns
- Migration notes provide clear guidance for manual changes

## Migration Notes
The new categories enable more targeted migrations:
```bash
pnpx codemod workleap/orbiter-to-hopper -c tags  # Tag components only
pnpx codemod workleap/orbiter-to-hopper -c menu   # Menu components only  
pnpx codemod workleap/orbiter-to-hopper -c overlay # Overlay components only
```